### PR TITLE
Add Symbolic Link Handling to Link Generation

### DIFF
--- a/src/commands/CopyLinkCommand.ts
+++ b/src/commands/CopyLinkCommand.ts
@@ -11,6 +11,7 @@ import {
 import { Selection } from '../utilities/Selection';
 import { WorkspaceData } from '../utilities/WorkspaceData';
 import { WorkspaceMap } from '../utilities/WorkspaceMap';
+import { INVALID_PATH } from '../constants';
 
 export abstract class CopyLinkCommand extends Disposable {
     private disposable: Disposable;
@@ -55,11 +56,16 @@ export abstract class CopyLinkCommand extends Disposable {
                         selection
                     );
 
-                    await env.clipboard.writeText(url);
-
-                    window.showInformationMessage(
-                        'Web link copied to the clipboard.'
-                    );
+                    if (url === INVALID_PATH) {
+                        window.showInformationMessage(
+                            'Web link could not be resolved.'
+                        );
+                    } else {
+                        await env.clipboard.writeText(url);
+                        window.showInformationMessage(
+                            'Web link copied to the clipboard.'
+                        );
+                    }
                 } else {
                     window.showErrorMessage(
                         'This workspace is not tracked by Git.'

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,4 @@
 export const EXTENSION_ID: string = 'gitweblinks';
 export const EXTENSION_NAME: string = 'Git Web Links';
 export const CONFIGURATION_KEY: string = EXTENSION_ID;
+export const INVALID_PATH: string = 'INVALID_PATH';


### PR DESCRIPTION
Now, if the user tries the copy a git link to a symbolic link, the extension
will attempt to resolve the true file path that the sym link points to.