### PR TITLE
Add handling for Git worktrees

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-gitweblinks",
-    "version": "1.9.0",
+    "version": "2.0.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/repository-finder.ts
+++ b/src/repository-finder.ts
@@ -1,4 +1,4 @@
-import { promises as fs } from 'fs';
+import * as fs from 'fs';
 import { dirname, join } from 'path';
 import { window } from 'vscode';
 
@@ -24,7 +24,7 @@ export class RepositoryFinder {
 
             log("Finding root directory of Git repository starting from '%s'...", workspaceRoot);
 
-            root = await this.findRepositoryRoot(workspaceRoot);
+            root = this.findRepositoryRoot(workspaceRoot);
 
             log("Root directory is '%s'.", root ?? '');
 
@@ -53,7 +53,7 @@ export class RepositoryFinder {
      * @param startingDirectory The full path of the directory to start searching from.
      * @returns The root of the repository, or `undefined` if the specified directory is not within a repository.
      */
-    private async findRepositoryRoot(startingDirectory: string): Promise<string | undefined> {
+    private findRepositoryRoot(startingDirectory: string): string | undefined {
         let current: string;
         let previous: string | undefined;
 
@@ -61,7 +61,8 @@ export class RepositoryFinder {
 
         while (current !== previous) {
             try {
-                if ((await fs.stat(join(current, '.git'))).isDirectory()) {
+                // .git will usually be a directory, but for a worktree it will be a file.
+                if (fs.existsSync(join(current, '.git'))) {
                     return current;
                 }
             } catch (ex) {

--- a/test/repository-finder.test.ts
+++ b/test/repository-finder.test.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { git } from '../src/git';
 import { RepositoryFinder } from '../src/repository-finder';
 
-import { Directory } from './helpers';
+import { Directory, setupRepository } from './helpers';
 
 describe('RepositoryFinder', () => {
     describe('find', () => {
@@ -52,9 +52,9 @@ describe('RepositoryFinder', () => {
             });
         });
 
-        it('should find the info when the workspace is a Git worktree', async () => {
+        it('should find the info when the workspace is a Git worktree.', async () => {
             worktree = await Directory.create();
-            await git(root.path, 'init');
+            await setupRepository(root.path);
             await git(root.path, 'remote', 'add', 'origin', 'https://github.com/example/repo');
             await git(root.path, 'worktree', 'add', worktree.path);
 

--- a/test/repository-finder.test.ts
+++ b/test/repository-finder.test.ts
@@ -9,6 +9,7 @@ describe('RepositoryFinder', () => {
     describe('find', () => {
         let finder: RepositoryFinder;
         let root: Directory;
+        let worktree: Directory | undefined;
 
         beforeEach(async () => {
             finder = new RepositoryFinder();
@@ -17,6 +18,10 @@ describe('RepositoryFinder', () => {
 
         afterEach(async () => {
             await root.dispose();
+            if (worktree) {
+                await worktree.dispose();
+                worktree = undefined;
+            }
         });
 
         it('should not find the info when the workspace is not in a Git repository.', async () => {
@@ -43,6 +48,18 @@ describe('RepositoryFinder', () => {
 
             expect(await finder.find(child)).to.deep.equal({
                 root: root.path,
+                remote: 'https://github.com/example/repo'
+            });
+        });
+
+        it('should find the info when the workspace is a Git worktree', async () => {
+            worktree = await Directory.create();
+            await git(root.path, 'init');
+            await git(root.path, 'remote', 'add', 'origin', 'https://github.com/example/repo');
+            await git(root.path, 'worktree', 'add', worktree.path);
+
+            expect(await finder.find(worktree.path)).to.deep.equal({
+                root: worktree.path,
                 remote: 'https://github.com/example/repo'
             });
         });


### PR DESCRIPTION
As described in #21, the extension doesn't currently work with [Git worktrees](https://git-scm.com/docs/git-worktree). This change updates the logic in RepositoryFinder to allow `.git` to be either a directory or a file (it's a file for worktrees). Provided that the directory containing `.git` is only ever used as the cwd for running git commands, not for digging around in the git folder structure, this should be safe.

I added one test, but please let me know if there are other specific things you'd like to see tested and where to add that.

Fixes #21.