### PR TITLE
Get default branch from remote

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,7 +6,7 @@ export const EXTENSION = {
 export const CONFIGURATION = {
     section: EXTENSION.id,
     linkType: 'linkType',
-    defaultBranch: 'defaultBranch',
+    customBranch: 'customBranch',
     showCopy: 'showCopy',
     showOpen: 'showOpen'
 };

--- a/src/repository-finder.ts
+++ b/src/repository-finder.ts
@@ -154,15 +154,14 @@ export class RepositoryFinder {
      * @returns The `Repository` object.
      */
     private async createRepository(root: string): Promise<Repository> {
-        let remote: string | undefined;
 
         log("Finding remote URL for '%s'...", root);
 
-        remote = await this.findRemote(root);
+        let remote = await this.findRemote(root);
 
         log("Remote URL is '%s'.", remote ?? '');
 
-        return { root, remote };
+        return { root, remoteName: remote?.name, remote: remote?.url };
     }
 
     /**
@@ -225,7 +224,7 @@ export class RepositoryFinder {
      * @param root The root of the repository.
      * @returns The URL of the "origin" remote if it exists, otherwise the first remote alphabetically, or `undefined` if there are no remotes.
      */
-    private async findRemote(root: string): Promise<string | undefined> {
+    private async findRemote(root: string): Promise<Remote | undefined> {
         let data: string;
         let remotes: Remote[];
         let remote: Remote;
@@ -249,7 +248,7 @@ export class RepositoryFinder {
             remote = remotes.sort((x, y) => x.name.localeCompare(y.name))[0];
         }
 
-        return remote?.url;
+        return remote;
     }
 
     /**

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -40,18 +40,21 @@ export class Settings {
             case 'defaultBranch':
                 return 'defaultBranch';
 
+            case 'customBranch':
+                return 'customBranch';
+
             default:
                 return 'commit';
         }
     }
 
     /**
-     * Gets the name of the branch to use when producing a link for the default branch.
+     * Gets the name of the branch to use when producing a link for the custom branch.
      *
-     * @returns The name of the default branch.
+     * @returns The name of the custom branch.
      */
-    public getDefaultBranch(): string {
-        return this.getConfiguration().get<string>(CONFIGURATION.defaultBranch) ?? 'master';
+    public getCustomBranch(): string {
+        return this.getConfiguration().get<string>(CONFIGURATION.customBranch) ?? 'master';
     }
 
     /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ import { StaticServer } from './schema';
 /**
  * The type of link to generate.
  */
-export type LinkType = 'commit' | 'branch' | 'defaultBranch';
+export type LinkType = 'commit' | 'branch' | 'defaultBranch' | 'customBranch';
 
 /**
  * Information about a Git repository.
@@ -18,6 +18,11 @@ export interface Repository {
      * The URL to the default remote, or `undefined` if the repository has no remotes.
      */
     readonly remote: string | undefined;
+
+    /**
+     * The name of the default remote.
+     */
+    readonly remoteName: string | undefined;
 }
 
 /**
@@ -28,6 +33,11 @@ export type RepositoryWithRemote = Omit<Repository, 'remote'> & {
      * The URL of the default remote.
      */
     readonly remote: string;
+
+    /**
+     * The name of the default remote.
+     */
+    readonly remoteName: string;
 };
 
 /**

--- a/test/commands/get-link-command.test.ts
+++ b/test/commands/get-link-command.test.ts
@@ -48,7 +48,7 @@ describe('GetLinkCommand', () => {
 
         file = Uri.file('/foo/bar');
         folder = Uri.file('/foo');
-        repository = { root: folder.toString(), remote: 'http://example.com' };
+        repository = { root: folder.toString(), remote: 'http://example.com', remoteName: 'origin' };
 
         showErrorMessage = sinon
             .stub(window, 'showErrorMessage')
@@ -98,7 +98,7 @@ describe('GetLinkCommand', () => {
     });
 
     it('should show an error if the repository does not have a remote.', async () => {
-        repository = { root: folder.toString(), remote: undefined };
+        repository = { root: folder.toString(), remote: undefined, remoteName: undefined };
 
         command = createCommand({ linkType: 'commit', includeSelection: true, action: 'copy' });
         await command.execute(file);
@@ -271,6 +271,6 @@ describe('GetLinkCommand', () => {
     }
 
     function getLinkTypes(): (LinkType | undefined)[] {
-        return ['commit', 'branch', 'defaultBranch', undefined];
+        return ['commit', 'branch', 'defaultBranch', 'customBranch', undefined];
     }
 });

--- a/test/commands/go-to-file-command.test.ts
+++ b/test/commands/go-to-file-command.test.ts
@@ -645,7 +645,7 @@ describe('GoToFileLinkCommand', () => {
         }
 
         if (folder.repository) {
-            currentRepository = { root: path, remote: folder.repository };
+            currentRepository = { root: path, remote: folder.repository, remoteName: 'origin' };
 
             if (currentWorkspace) {
                 let workspaceRepositories: Repository[];

--- a/test/handlers.test.ts
+++ b/test/handlers.test.ts
@@ -167,7 +167,8 @@ describe('Link handlers', function () {
 
                     repository = {
                         root: root.path,
-                        remote
+                        remote,
+                        remoteName: 'origin'
                     };
 
                     handler = provider.select(repository);

--- a/test/link-handler.test.ts
+++ b/test/link-handler.test.ts
@@ -25,7 +25,8 @@ describe('LinkHandler', function () {
 
         repository = {
             root: root.path,
-            remote: 'http://example.com'
+            remote: 'http://example.com',
+            remoteName: 'origin'
         };
     });
 
@@ -73,12 +74,12 @@ describe('LinkHandler', function () {
             ).to.equal('foo');
         });
 
-        it('should use the default branch name as the "ref" value when the link type is "defaultBranch".', async () => {
-            sinon.stub(Settings.prototype, 'getDefaultBranch').returns('bar');
+        it('should use the custom branch name as the "ref" value when the link type is "customBranch".', async () => {
+            sinon.stub(Settings.prototype, 'getCustomBranch').returns('bar');
 
             await setupRepository(root.path);
 
-            expect(await createUrl({ url: '{{ ref }}' }, { type: 'defaultBranch' })).to.equal(
+            expect(await createUrl({ url: '{{ ref }}' }, { type: 'customBranch' })).to.equal(
                 'bar'
             );
         });
@@ -322,7 +323,8 @@ describe('LinkHandler', function () {
 
             repository = {
                 root: link,
-                remote: 'http://example.com'
+                remote: 'http://example.com',
+                remoteName: 'origin'
             };
 
             foo = path.join(real, 'foo.js');

--- a/test/repository-finder.test.ts
+++ b/test/repository-finder.test.ts
@@ -94,6 +94,7 @@ describe('RepositoryFinder', function () {
 
             expect(await finder.findRepository(root.path)).to.deep.equal({
                 root: root.path,
+                remoteName: 'origin',
                 remote: 'https://github.com/example/repo'
             });
         });
@@ -108,6 +109,7 @@ describe('RepositoryFinder', function () {
 
             expect(await finder.findRepository(child)).to.deep.equal({
                 root: root.path,
+                remoteName: 'origin',
                 remote: 'https://github.com/example/repo'
             });
         });
@@ -123,6 +125,7 @@ describe('RepositoryFinder', function () {
 
             expect(await finder.findRepository(file)).to.deep.equal({
                 root: root.path,
+                remoteName: 'origin',
                 remote: 'https://github.com/example/repo'
             });
         });
@@ -135,6 +138,7 @@ describe('RepositoryFinder', function () {
 
             expect(await finder.findRepository(worktree.path)).to.deep.equal({
                 root: worktree.path,
+                remoteName: 'origin',
                 remote: 'https://github.com/example/repo'
             });
         });
@@ -147,6 +151,7 @@ describe('RepositoryFinder', function () {
 
             expect(await finder.findRepository(root.path)).to.deep.equal({
                 root: root.path,
+                remoteName: 'origin',
                 remote: 'https://github.com/example/repo'
             });
         });
@@ -159,6 +164,7 @@ describe('RepositoryFinder', function () {
 
             expect(await finder.findRepository(root.path)).to.deep.equal({
                 root: root.path,
+                remoteName: 'alpha',
                 remote: 'https://github.com/example/alpha'
             });
         });
@@ -268,9 +274,9 @@ describe('RepositoryFinder', function () {
             repositories.sort((x, y) => x.root.localeCompare(y.root));
 
             expect(repositories).to.deep.equal([
-                { root: alpha, remote: 'https://github.com/example/alpha' },
-                { root: beta, remote: undefined },
-                { root: gamma, remote: 'https://github.com/example/gamma' }
+                { root: alpha, remoteName: 'origin', remote: 'https://github.com/example/alpha' },
+                { root: beta, remoteName: undefined, remote: undefined },
+                { root: gamma, remoteName: 'origin', remote: 'https://github.com/example/gamma' }
             ]);
         });
 

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -70,15 +70,15 @@ describe('Settings', () => {
         });
     });
 
-    describe('getDefaultBranch', () => {
+    describe('getCustomBranch', () => {
         it('should return "master" if there is no stored value.', () => {
-            setup({ defaultBranch: undefined });
-            expect(settings.getDefaultBranch()).to.equal('master');
+            setup({ customBranch: undefined });
+            expect(settings.getCustomBranch()).to.equal('master');
         });
 
         it('should return the stored value when it exists.', () => {
-            setup({ defaultBranch: 'foo' });
-            expect(settings.getDefaultBranch()).to.equal('foo');
+            setup({ customBranch: 'foo' });
+            expect(settings.getCustomBranch()).to.equal('foo');
         });
     });
 

--- a/test/utilities.test.ts
+++ b/test/utilities.test.ts
@@ -5,11 +5,11 @@ import { hasRemote, normalizeUrl } from '../src/utilities';
 describe('utilities', () => {
     describe('hasRemote', () => {
         it('returns true when repository has a remote.', () => {
-            expect(hasRemote({ remote: 'a', root: 'b' })).to.be.true;
+            expect(hasRemote({ remote: 'a', root: 'b', remoteName: 'origin' })).to.be.true;
         });
 
         it('returns false when repository does not have a remote.', () => {
-            expect(hasRemote({ remote: undefined, root: 'b' })).to.be.false;
+            expect(hasRemote({ remote: undefined, root: 'b', remoteName: 'origin' })).to.be.false;
         });
     });
 


### PR DESCRIPTION
Hello :)

My personal favorite option is **default branch**. But we have many repositories and the default name is different everywhere: master, dev, develop, release, qa...
I suggest getting the default branch name as `origin/HEAD` with the same command that gets the branch name for `HEAD`. This works fine with the `rev-parse --abbrev-ref`, but I'm not sure how it would work with the `symbolic-ref`