### PR TITLE
extend Azure DevOps matching

### DIFF
--- a/shared/handlers/azure-dev-ops-cloud.json
+++ b/shared/handlers/azure-dev-ops-cloud.json
@@ -3,9 +3,19 @@
     "name": "Azure Dev Ops Cloud",
     "server": [
         {
-            "pattern": "https:\\/\\/(?:.+@)?dev\\.azure\\.com\\/([^\\/]+)\\/([^\\/]+)\\/_git\\/.+",
-            "http": "https://dev.azure.com/{{ match[1] }}/{{ match[2] }}/_git",
-            "ssh": "git@ssh.dev.azure.com:v3/{{ match[1] }}/{{ match[2] }}"
+            "pattern": "http(s)?:\\/\\/(?:.+@)?dev\\.azure\\.com\\/([^\\/]+)\\/([^\\/]+)\\/_git\\/.+",
+            "http": "http{{ match[1] }}://dev.azure.com/{{ match[2] }}/{{ match[3] }}/_git",
+            "ssh": "git@ssh.dev.azure.com:v3/{{ match[2] }}/{{ match[3] }}"
+        },
+        {
+            "pattern": "http(s)?:\\/\\/([^\\/]+)\\/tfs\\/([^\\/]+)\\/([^\\/]+)\\/_git\\/.+",
+            "http": "http{{ match[1] }}://{{ match[2] }}/tfs/{{ match[3] }}/{{ match[4] }}/_git",
+            "ssh": ""
+        },
+        {
+            "pattern": "http(s)?:\\/\\/tfs\\.([^\\/]+)\\/([^\\/]+)\\/([^\\/]+)\\/_git\\/.+",
+            "http": "http{{ match[1] }}://tfs.{{ match[2] }}/{{ match[3] }}/{{ match[4] }}/_git",
+            "ssh": ""
         },
         {
             "pattern": "^(?:git@)?ssh\\.dev\\.azure\\.com:v3\\/([^\\/]+)\\/([^\\/]+)\\/.+$",


### PR DESCRIPTION
I extended Azure DevOps configuration. We use the following url at work
https://tfs.companyname.net/tfs/

here are some more examples of possible addresses:
https://specsolutions.gitbook.io/specsync/important-concepts/what-is-my-tfs-project-url#:~:text=Typical%20valid%20Azure%20DevOps%20project,DevOps%20Server%20%2F%20Team%20Foundation%20Server)

https://docs.microsoft.com/en-us/azure/devops/server/admin/websitesettings?view=azure-devops-2020#internal-and-external-certificate-authorities
