### PR TITLE
Add setting to use github.dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -302,6 +302,11 @@
                     "type": "boolean",
                     "description": "Controls the visibility of the 'Open Link' menu item.",
                     "default": false
+                },
+                "gitweblinks.useGithubDev": {
+                    "type": "boolean",
+                    "description": "Generates links to github.dev instead of github.com.",
+                    "default": false
                 }
             }
         }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,7 +8,8 @@ export const CONFIGURATION = {
     linkType: 'linkType',
     defaultBranch: 'defaultBranch',
     showCopy: 'showCopy',
-    showOpen: 'showOpen'
+    showOpen: 'showOpen',
+    useGithubDev: 'useGithubDev'
 };
 
 export const CONTEXT = {

--- a/src/link-handler.ts
+++ b/src/link-handler.ts
@@ -143,6 +143,10 @@ export class LinkHandler {
             url += this.selectionTemplate.render(data);
         }
 
+        if (this.settings.shouldUseGithubDev()) {
+            url = url.replace('github.com', 'github.dev');
+        }
+
         url = this.applyModifications(
             url,
             this.queryModifications.filter((x) => x.pattern.test(file.filePath))

--- a/src/link-handler.ts
+++ b/src/link-handler.ts
@@ -144,7 +144,7 @@ export class LinkHandler {
         }
 
         if (this.settings.shouldUseGithubDev()) {
-            url = url.replace('github.com', 'github.dev');
+            url = url.replace('https://github.com', 'https://github.dev');
         }
 
         url = this.applyModifications(

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -73,6 +73,15 @@ export class Settings {
     }
 
     /**
+     * Gets the setting that controls whether github.dev links should be used.
+     *
+     * @returns True if github.dev should be used; otherwise, github.com should be used.
+     */
+    public shouldUseGithubDev(): boolean {
+        return !!this.getConfiguration().get(CONFIGURATION.useGithubDev);
+    }
+
+    /**
      * Gets the configuration for the workspace.
      *
      * @returns The configuration.


### PR DESCRIPTION
![Demo gif](https://user-images.githubusercontent.com/19893438/137399846-ae39da2c-f628-406b-9990-c368f77ca766.gif)

I use permalinks to provide more context in issues and comments. This works decently-well on github.com, but it's even better on [github.dev](https://docs.github.com/en/codespaces/the-githubdev-web-based-editor)! You can quickly jump into a project, make small changes, and explore code in a web-based version of VS Code with the same search, source control, and extensions as the desktop app.

To open a repo or permalink in github.dev, all you need to do is change "github.com" to "github.dev". This PR accomplishes that with a trivial `replace('https://github.com', 'https://github.dev')` when the new `gitweblinks.useGithubDev` setting is enabled. It's disabled by default and the only way to enable this new behavior is to enable that new setting.

### Examples

- File: https://github.dev/reduckted/vscode-gitweblinks/blob/7f2ad454065408838e9678851a4769869873cb26/src/link-handler.ts
- Selection: https://github.dev/reduckted/vscode-gitweblinks/blob/7f2ad454065408838e9678851a4769869873cb26/src/link-handler.ts#L109-L152

### Changes

- Adds `gitweblinks.useGithubDev` setting
- Generates links to `github.dev` instead of `github.com` (when enabled)

### Notes

I wasn't sure where to implement this behavior. It seems like replacing github.com as needed is cleaner than modifying the existing GitHub handler. Awesome work with this extension, it's exactly what I was looking for!