### PR TITLE
Add keyboard shortcut for copy selection menu item

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -131,6 +131,13 @@
                 "category": "Git Web Links"
             }
         ],
+        "keybindings": [
+            {
+                "command": "gitweblinks.copySelection",
+                "key": "ctrl+g ctrl+l",
+                "mac": "cmd+g cmd+l"
+            }
+        ],
         "menus": {
             "editor/context": [
                 {


### PR DESCRIPTION
I've added a shortcut to the menu item as per the docs, but not sure how to test

This works with my `keybindings.json` as a custom shortcut.

```json
  {
    "key": "cmd+g cmd+l",
    "command": "gitweblinks.copySelection",
    "when": "editorTextFocus",
  }
```

RE: https://github.com/reduckted/GitWebLinks/issues/44