### PR TITLE
Support SSH user specifications other than "git"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ on:
       - "**"
 
   pull_request:
-    types: [opened, synchronize, edited]
 
 jobs:
   build-vscode:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.14.1 (2026-01-16)
+
+-   🐛 Supported SSH user specifications other than "git".
+-   🔨 Dependency updates.
+
 ## 2.14.0 (2025-02-05)
 
 ### Changes

--- a/shared/handlers/azure-dev-ops-cloud.json
+++ b/shared/handlers/azure-dev-ops-cloud.json
@@ -8,7 +8,7 @@
             "ssh": "git@ssh.dev.azure.com:v3/{{ match[1] }}/{{ match[2] }}"
         },
         {
-            "remotePattern": "^(?:git@)?ssh\\.dev\\.azure\\.com:v3\\/([^\\/]+)\\/([^\\/]+)\\/.+$",
+            "remotePattern": "^ssh\\.dev\\.azure\\.com:v3\\/([^\\/]+)\\/([^\\/]+)\\/.+$",
             "http": "https://dev.azure.com/{{ match[1] }}/{{ match[2] }}/_git",
             "ssh": "git@ssh.dev.azure.com:v3/{{ match[1] }}/{{ match[2] }}",
             "webPattern": "^ONLY MATCH TO SSH REMOTE URLS$"
@@ -77,6 +77,13 @@
                 "remote": "https://dev.azure.com/user/foo/_git/bar",
                 "result": "https://dev.azure.com/user/foo/_git/bar?path=%2Fsrc%2Ffile.txt&version=GC{{ commit }}"
             },
+            "misc": [
+                {
+                    "name": "SSH with non-standard user specification",
+                    "remote": "user@ssh.dev.azure.com:v3/user/foo/bar",
+                    "result": "https://dev.azure.com/user/foo/_git/bar?path=%2Fsrc%2Ffile.txt&version=GBmaster"
+                }
+            ],
             "selection": {
                 "remote": "https://dev.azure.com/user/foo/_git/bar",
                 "point": {

--- a/shared/handlers/bitbucket-cloud.json
+++ b/shared/handlers/bitbucket-cloud.json
@@ -3,7 +3,7 @@
     "name": "Bitbucket Cloud",
     "server": {
         "http": "https://bitbucket.org",
-        "ssh": "git@bitbucket.org"
+        "ssh": "bitbucket.org"
     },
     "branchRef": "abbreviated",
     "url": [
@@ -71,6 +71,11 @@
                     "fileName": "src/file.txt",
                     "remote": "https://bitbucket.org/foo/bar.git",
                     "result": "https://bitbucket.org/foo/bar/src/test-branch/src/file.txt"
+                },
+                {
+                    "name": "SSH with non-standard user specification",
+                    "remote": "user@bitbucket.org:foo/bar.git",
+                    "result": "https://bitbucket.org/foo/bar/src/master/src/file.txt"
                 }
             ],
             "selection": {

--- a/shared/handlers/github.json
+++ b/shared/handlers/github.json
@@ -8,7 +8,7 @@
             "ssh": "git@github.com"
         },
         {
-            "remotePattern": "^(?:git@)?github\\.com",
+            "remotePattern": "^github\\.com",
             "http": "https://github.com",
             "ssh": "git@github.com",
             "webPattern": "^ONLY MATCH TO SSH REMOTE URLS$"
@@ -105,6 +105,11 @@
                     "settings": {
                         "useGitHubDev": false
                     }
+                },
+                {
+                    "name": "SSH with non-standard user specification",
+                    "remote": "user@github.com:foo/bar.git",
+                    "result": "https://github.com/foo/bar/blob/master/src/file.txt"
                 }
             ],
             "selection": {

--- a/shared/handlers/gitlab.json
+++ b/shared/handlers/gitlab.json
@@ -3,7 +3,7 @@
     "name": "GitLab",
     "server": {
         "http": "https://gitlab.com",
-        "ssh": "git@gitlab.com"
+        "ssh": "gitlab.com"
     },
     "branchRef": "abbreviated",
     "url": "{{ base }}/{{ repository }}/-/blob/{{ ref | encode_uri }}/{{ file | encode_uri }}",
@@ -51,6 +51,13 @@
                 "remote": "https://gitlab.com/foo/bar.git",
                 "result": "https://gitlab.com/foo/bar/-/blob/{{ commit }}/src/file.txt"
             },
+            "misc": [
+                {
+                    "name": "SSH with non-standard user specification",
+                    "remote": "user@gitlab.com:foo/bar.git",
+                    "result": "https://gitlab.com/foo/bar/-/blob/master/src/file.txt"
+                }
+            ],
             "selection": {
                 "remote": "https://gitlab.com/foo/bar.git",
                 "point": {

--- a/shared/handlers/visual-studio-team-services.json
+++ b/shared/handlers/visual-studio-team-services.json
@@ -3,9 +3,9 @@
     "name": "Visual Studio Team Services",
     "server": [
         {
-            "remotePattern": "^([^.]+)@vs-ssh\\.visualstudio\\.com:22(?:/(.+))?/_ssh/.+$",
-            "http": "https://{{ match[1] }}.visualstudio.com{% if match[2] %}/{{ match[2] }}{% endif %}/_git",
-            "ssh": "{{ match[1] }}@vs-ssh.visualstudio.com:22{% if match[2] %}/{{ match[2] }}{% endif %}/_ssh",
+            "remotePattern": "^vs-ssh\\.visualstudio\\.com:22(?:/(.+))?/_ssh/.+$",
+            "http": "https://{{ sshUserSpecification }}.visualstudio.com{% if match[1] %}/{{ match[1] }}{% endif %}/_git",
+            "ssh": "{{ sshUserSpecification }}@vs-ssh.visualstudio.com:22{% if match[1] %}/{{ match[1] }}{% endif %}/_ssh",
             "webPattern": "^ONLY MATCH TO SSH REMOTE URLS$"
         },
         {

--- a/visual-studio/source/GitWebLinks/Properties/AssemblyInfo.cs
+++ b/visual-studio/source/GitWebLinks/Properties/AssemblyInfo.cs
@@ -13,6 +13,6 @@ using System.Windows;
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
 [assembly: NeutralResourcesLanguage("en-US")]
-[assembly: AssemblyVersion("2.14.0.0")]
-[assembly: AssemblyFileVersion("2.14.0.0")]
+[assembly: AssemblyVersion("2.14.1.0")]
+[assembly: AssemblyFileVersion("2.14.1.0")]
 [assembly: ThemeInfo(ResourceDictionaryLocation.None, ResourceDictionaryLocation.SourceAssembly)] 

--- a/visual-studio/source/GitWebLinks/Services/LinkHandler.cs
+++ b/visual-studio/source/GitWebLinks/Services/LinkHandler.cs
@@ -37,7 +37,7 @@ public class LinkHandler : ILinkHandler {
 
 
     public async Task<bool> HandlesRemoteUrlAsync(string remoteUrl) {
-        return await _server.MatchRemoteUrlAsync(UrlHelpers.Normalize(remoteUrl)) is not null;
+        return await _server.MatchRemoteUrlAsync(remoteUrl) is not null;
     }
 
 
@@ -86,10 +86,6 @@ public class LinkHandler : ILinkHandler {
             throw new NotSupportedException($"Unknown link target {options.Target.GetType().Name}.");
         }
 
-        // Adjust the remote URL so that it's in a
-        // standard format that we can manipulate.
-        remoteUrl = UrlHelpers.Normalize(remoteUrl);
-
         address = await GetAddressAsync(remoteUrl);
         relativePath = GetRelativePath(repository.Root, file.FilePath);
 
@@ -100,7 +96,8 @@ public class LinkHandler : ILinkHandler {
             .Add("ref", refValue)
             .Add("commit", await GetRefAsync(LinkType.Commit, repository.Root, repository.Remote))
             .Add("file", relativePath)
-            .Add("type", refType == RefType.Commit ? "commit" : "branch");
+            .Add("type", refType == RefType.Commit ? "commit" : "branch")
+            .Add("sshUserSpecification", UrlHelpers.GetSshUserSpecification(remoteUrl));
 
         if (file.Selection is not null) {
             data.Add("startLine", file.Selection.StartLine);
@@ -183,6 +180,7 @@ public class LinkHandler : ILinkHandler {
     private static string GetRepositoryPath(string remoteUrl, StaticServer address) {
         string repositoryPath;
 
+        remoteUrl = UrlHelpers.Normalize(remoteUrl);
 
         // Remove the server's address from the start of the URL.
         // Note that the remote URL and both URLs in the server

--- a/visual-studio/source/GitWebLinks/Types/RemoteServer.cs
+++ b/visual-studio/source/GitWebLinks/Types/RemoteServer.cs
@@ -50,15 +50,22 @@ public class RemoteServer {
                 StaticServer? result;
 
 
-                match = pattern.Match(url);
+                match = pattern.Match(UrlHelpers.Normalize(url));
 
                 if (match.Success) {
                     TemplateContext context;
+                    string sshUserSpecification;
 
+
+                    sshUserSpecification = UrlHelpers.GetSshUserSpecification(url);
 
                     // The URL matched the pattern. Render the templates to get the HTTP
                     // and SSH URLs, making the match available for the templates to use.
-                    context = TemplateData.Create().Add(match).AsTemplateContext();
+                    context = TemplateData
+                        .Create()
+                        .Add(match)
+                        .Add("sshUserSpecification", sshUserSpecification)
+                        .AsTemplateContext();
 
                     result = new StaticServer(
                         server.Http.Render(context),

--- a/visual-studio/source/GitWebLinks/Utilities/UrlHelpers.cs
+++ b/visual-studio/source/GitWebLinks/Utilities/UrlHelpers.cs
@@ -8,10 +8,13 @@ namespace GitWebLinks;
 public static class UrlHelpers {
 
     private static readonly Regex HttpPattern = new("(https?://)[^@]+@(.+)");
+    private static readonly Regex IsHttpPattern = new("^https?://");
+    private static readonly Regex SshUserSpecificationPattern = new("^([^@:]+)@(.+)");
 
 
     public static string Normalize(string url) {
         Match httpMatch;
+        Match userSpecificationMatch;
 
 
         // Remove the SSH prefix if it exists.
@@ -19,9 +22,12 @@ public static class UrlHelpers {
             url = url.Substring(6);
         }
 
-        // Remove the "git@" prefix if it exists.
-        if (url.StartsWith("git@", StringComparison.Ordinal)) {
-            url = url.Substring(4);
+        // Remove the user specification (for example, "git@")
+        // from the start of the URL if there is one.
+        userSpecificationMatch = SshUserSpecificationPattern.Match(url);
+
+        if (userSpecificationMatch.Success) {
+            url = userSpecificationMatch.Groups[2].Value;
         }
 
         // If the URL is an HTTP(S) address, check if there's
@@ -37,6 +43,23 @@ public static class UrlHelpers {
         }
 
         return url;
+    }
+
+
+    public static string GetSshUserSpecification(string url) {
+        Match match;
+
+        if (IsHttpPattern.IsMatch(url)) {
+            return "";
+        }
+
+        if (url.StartsWith("ssh://")) {
+            url = url.Substring(6);
+        }
+
+        match = SshUserSpecificationPattern.Match(url);
+
+        return match.Success ? match.Groups[1].Value : "";
     }
 
 }

--- a/visual-studio/source/GitWebLinks/source.extension.cs
+++ b/visual-studio/source/GitWebLinks/source.extension.cs
@@ -11,7 +11,7 @@ namespace GitWebLinks
         public const string Name = "Git Web Links";
         public const string Description = @"Copy links to files in their online Git repositories.";
         public const string Language = "en-US";
-        public const string Version = "2.14.0";
+        public const string Version = "2.14.1";
         public const string Author = "reduckted";
         public const string Tags = "";
     }

--- a/visual-studio/source/GitWebLinks/source.extension.vsixmanifest
+++ b/visual-studio/source/GitWebLinks/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="GitWebLinks.c090a256-229d-440e-8f5d-34306611b61b" Version="2.14.0" Language="en-US" Publisher="reduckted" />
+        <Identity Id="GitWebLinks.c090a256-229d-440e-8f5d-34306611b61b" Version="2.14.1" Language="en-US" Publisher="reduckted" />
         <DisplayName>Git Web Links</DisplayName>
         <Description xml:space="preserve">Copy links to files in their online Git repositories.</Description>
         <MoreInfo>https://github.com/reduckted/GitWebLinks</MoreInfo>

--- a/visual-studio/tests/GitWebLinks.UnitTests/Types/RemoteServerTests.cs
+++ b/visual-studio/tests/GitWebLinks.UnitTests/Types/RemoteServerTests.cs
@@ -251,7 +251,7 @@ public static class RemoteServerTests {
                         null
                     ),
                     new DynamicServer(
-                        new Regex("ssh://git@example\\.com:9000/_([^/]+)"),
+                        new Regex("example\\.com:9000/_([^/]+)"),
                         Parser.Parse("http://example.com:8000/repos/{{ match[1] }}"),
                         Parser.Parse("ssh://git@example.com:9000/_{{ match[1] }}"),
                         new Regex("^$"), // This server should only match SSH remote URLs.

--- a/visual-studio/tests/GitWebLinks.UnitTests/Utilities/UrlHelpersTests.cs
+++ b/visual-studio/tests/GitWebLinks.UnitTests/Utilities/UrlHelpersTests.cs
@@ -29,8 +29,14 @@ public static class UrlHelpersTests {
 
 
         [Fact]
-        public void ShouldRemoveTheGitAtPrefix() {
+        public void ShouldRemoveTheGitAtUserSpecificationPrefix() {
             Assert.Equal("example.com", UrlHelpers.Normalize("git@example.com"));
+        }
+
+
+        [Fact]
+        public void ShouldRemoveNonStandardUserSpecificationPrefix() {
+            Assert.Equal("example.com", UrlHelpers.Normalize("foo@example.com"));
         }
 
 
@@ -55,6 +61,38 @@ public static class UrlHelpersTests {
         [Fact]
         public void ShouldRemoveTheTrailingSlashFromSshUrls() {
             Assert.Equal("example.com", UrlHelpers.Normalize("ssh://example.com/"));
+        }
+
+    }
+
+
+    public class GetSshUserSpecificationMethod {
+
+        [Fact]
+        public void ShouldReturnEmptyStringForHttpUrls() {
+            Assert.Equal("", UrlHelpers.GetSshUserSpecification("http://me@example.com"));
+        }
+
+
+        [Fact]
+        public void ShouldReturnEmptyStringForHttpsUrls() {
+            Assert.Equal("", UrlHelpers.GetSshUserSpecification("https://me@example.com"));
+        }
+
+
+        [Theory]
+        [InlineData("git")]
+        [InlineData("foo")]
+        public void ShouldReturnUserSpecificationFromSshUrlsWithProtocol(string user) {
+            Assert.Equal(user, UrlHelpers.GetSshUserSpecification($"ssh://{user}@example.com"));
+        }
+
+
+        [Theory]
+        [InlineData("git")]
+        [InlineData("foo")]
+        public void ShouldReturnUserSpecificationFromSshUrlsWithoutProtocol(string user) {
+            Assert.Equal(user, UrlHelpers.GetSshUserSpecification($"{user}@example.com"));
         }
 
     }

--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-gitweblinks",
-    "version": "2.14.0",
+    "version": "2.14.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-gitweblinks",
-            "version": "2.14.0",
+            "version": "2.14.1",
             "license": "MIT",
             "dependencies": {
                 "liquidjs": "10.24.0"
@@ -1134,6 +1134,7 @@
             "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jridgewell/set-array": "^1.2.1",
                 "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -1158,6 +1159,7 @@
             "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6.0.0"
             }
@@ -1168,6 +1170,7 @@
             "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.25"
@@ -1649,6 +1652,7 @@
             "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
             "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/eslint": "*",
                 "@types/estree": "*"
@@ -1742,7 +1746,6 @@
             "integrity": "sha512-XtssGWJvypyM2ytBnSnKtHYOGT+4ZwTnBVl36TA4nRO2f4PRNGz5/1OszHzcZCvcBMh+qb7I06uoCmLTRdR9og==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
                 "@typescript-eslint/scope-manager": "8.51.0",
@@ -1782,7 +1785,6 @@
             "integrity": "sha512-3xP4XzzDNQOIqBMWogftkwxhg5oMKApqY0BAflmLZiFYHqyhSOxv/cd/zPQLTcCXr4AkaKb25joocY0BD1WC6A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.51.0",
                 "@typescript-eslint/types": "8.51.0",
@@ -2337,6 +2339,7 @@
             "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
             "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/helper-numbers": "1.13.2",
                 "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
@@ -2346,25 +2349,29 @@
             "version": "1.13.2",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
             "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/@webassemblyjs/helper-api-error": {
             "version": "1.13.2",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
             "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/@webassemblyjs/helper-buffer": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
             "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/@webassemblyjs/helper-numbers": {
             "version": "1.13.2",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
             "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/floating-point-hex-parser": "1.13.2",
                 "@webassemblyjs/helper-api-error": "1.13.2",
@@ -2375,13 +2382,15 @@
             "version": "1.13.2",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
             "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/@webassemblyjs/helper-wasm-section": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
             "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@webassemblyjs/helper-buffer": "1.14.1",
@@ -2394,6 +2403,7 @@
             "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
             "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@xtuc/ieee754": "^1.2.0"
             }
@@ -2403,6 +2413,7 @@
             "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
             "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@xtuc/long": "4.2.2"
             }
@@ -2411,13 +2422,15 @@
             "version": "1.13.2",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
             "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/@webassemblyjs/wasm-edit": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
             "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@webassemblyjs/helper-buffer": "1.14.1",
@@ -2434,6 +2447,7 @@
             "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
             "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
@@ -2447,6 +2461,7 @@
             "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
             "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@webassemblyjs/helper-buffer": "1.14.1",
@@ -2459,6 +2474,7 @@
             "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
             "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@webassemblyjs/helper-api-error": "1.13.2",
@@ -2473,6 +2489,7 @@
             "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
             "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@xtuc/long": "4.2.2"
@@ -2482,13 +2499,15 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
             "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/@xtuc/long": {
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
             "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/acorn": {
             "version": "8.15.0",
@@ -2496,7 +2515,6 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -2530,7 +2548,6 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -2548,6 +2565,7 @@
             "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ajv": "^8.0.0"
             },
@@ -2566,6 +2584,7 @@
             "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3"
             },
@@ -2829,7 +2848,8 @@
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/c8": {
             "version": "10.1.3",
@@ -2936,14 +2956,14 @@
                     "type": "github",
                     "url": "https://github.com/sponsors/ai"
                 }
-            ]
+            ],
+            "peer": true
         },
         "node_modules/chai": {
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
             "integrity": "sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "assertion-error": "^1.1.0",
                 "check-error": "^1.0.3",
@@ -3074,6 +3094,7 @@
             "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
             "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=6.0"
             }
@@ -3557,7 +3578,8 @@
             "version": "1.5.50",
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.50.tgz",
             "integrity": "sha512-eMVObiUQ2LdgeO1F/ySTXsvqvxb6ZH2zPGaMYsWzRDdOddUa77tdmI0ltg+L16UpbWdhPmuF3wIQYyQq65WfZw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/emoji-regex": {
             "version": "9.2.2",
@@ -3637,7 +3659,8 @@
             "version": "1.5.3",
             "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.3.tgz",
             "integrity": "sha512-i1gCgmR9dCl6Vil6UKPI/trA69s08g/syhiDK9TG0Nf1RJjjFI+AzoWW7sPufzkgYAn861skuCwJa0pIIHYxvg==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/es-object-atoms": {
             "version": "1.1.1",
@@ -3738,7 +3761,6 @@
             "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -3814,7 +3836,6 @@
             "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "eslint-config-prettier": "bin/cli.js"
             },
@@ -4529,7 +4550,8 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
             "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/glob/node_modules/minimatch": {
             "version": "10.1.1",
@@ -5073,6 +5095,7 @@
             "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/node": "*",
                 "merge-stream": "^2.0.0",
@@ -5088,6 +5111,7 @@
             "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -5138,7 +5162,8 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
             "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/json-schema-traverse": {
             "version": "1.0.0",
@@ -5371,6 +5396,7 @@
             "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
             "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=6.11.5"
             }
@@ -5565,7 +5591,8 @@
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
             "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/merge2": {
             "version": "1.4.1",
@@ -5868,7 +5895,8 @@
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
             "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/node-abi": {
             "version": "3.63.0",
@@ -5894,7 +5922,8 @@
             "version": "2.0.18",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
             "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/node-sarif-builder": {
             "version": "3.2.0",
@@ -6616,7 +6645,6 @@
             "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -7016,6 +7044,7 @@
             "integrity": "sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/json-schema": "^7.0.9",
                 "ajv": "^8.9.0",
@@ -7345,6 +7374,7 @@
             "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
@@ -7356,6 +7386,7 @@
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
             "dev": true,
             "license": "BSD-3-Clause",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -7774,6 +7805,7 @@
             "integrity": "sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "@jridgewell/source-map": "^0.3.3",
                 "acorn": "^8.8.2",
@@ -7793,6 +7825,7 @@
             "integrity": "sha512-RVCsMfuD0+cTt3EwX8hSl2Ks56EbFHWmhluwcqoPKtBnfjiT6olaq7PRIRfhyU8nnC2MrnDrBLfrD/RGE+cVXQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.25",
                 "jest-worker": "^27.4.5",
@@ -7827,7 +7860,8 @@
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/test-exclude": {
             "version": "7.0.1",
@@ -7969,7 +8003,6 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -8166,7 +8199,6 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -8259,6 +8291,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "escalade": "^3.2.0",
                 "picocolors": "^1.1.0"
@@ -8355,6 +8388,7 @@
             "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.1.tgz",
             "integrity": "sha512-8wrBCMtVhqcXP2Sup1ctSkga6uc2Bx0IIvKyT7yTFier5AXHooSI+QyQQAtTb7+E0IUCCKyTFmXqdqgum2XWGg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "glob-to-regexp": "^0.4.1",
                 "graceful-fs": "^4.1.2"
@@ -8369,6 +8403,7 @@
             "integrity": "sha512-lQ3CPiSTpfOnrEGeXDwoq5hIGzSjmwD72GdfVzF7CQAI7t47rJG9eDWvcEkEn3CUQymAElVvDg3YNTlCYj+qUQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.6",
@@ -8416,6 +8451,7 @@
             "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
             "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=10.13.0"
             }
@@ -8425,6 +8461,7 @@
             "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
             "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "esrecurse": "^4.3.0",
                 "estraverse": "^4.1.1"
@@ -8438,6 +8475,7 @@
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
             "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=4.0"
             }

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-gitweblinks",
     "displayName": "Git Web Links for VS Code",
     "description": "Copy links to files in their online Git repositories",
-    "version": "2.14.0",
+    "version": "2.14.1",
     "publisher": "reduckted",
     "homepage": "https://github.com/reduckted/GitWebLinks",
     "repository": {

--- a/vscode/src/remote-server.ts
+++ b/vscode/src/remote-server.ts
@@ -4,7 +4,7 @@ import type { Mutable } from './types';
 
 import { log } from './log';
 import { parseTemplate } from './templates';
-import { normalizeUrl } from './utilities';
+import { getSshUserSpecification, normalizeUrl } from './utilities';
 
 /**
  * Defines a remote server that can be matched to a Git server URL.
@@ -147,23 +147,23 @@ function createDynamicServerMatcher(server: DynamicServer): Matcher {
         return (url) => {
             let match: RegExpMatchArray | null;
 
-            match = pattern.exec(url);
+            match = pattern.exec(normalizeUrl(url));
 
             if (match) {
-                let http: string;
+                let sshUserSpecification: string;
                 let server: Mutable<StaticServer>;
 
-                http = httpTemplate.render({ match });
+                sshUserSpecification = getSshUserSpecification(url);
 
                 // The URL matched the pattern. Render the templates to get the
                 // URLs, making the match available for the templates to use.
                 server = {
-                    http,
-                    ssh: sshTemplate.render({ match })
+                    http: httpTemplate.render({ match, sshUserSpecification }),
+                    ssh: sshTemplate.render({ match, sshUserSpecification })
                 };
 
                 if (webTemplate) {
-                    server.web = webTemplate?.render({ match });
+                    server.web = webTemplate?.render({ match, sshUserSpecification });
                 }
 
                 return server;

--- a/vscode/test/remote-server.test.ts
+++ b/vscode/test/remote-server.test.ts
@@ -200,7 +200,7 @@ describe('RemoteServer', () => {
                     ssh: 'ssh://git@example.com:9000/_{{ match[1] }}'
                 },
                 {
-                    remotePattern: 'ssh://git@example\\.com:9000/_([^/]+)',
+                    remotePattern: 'example\\.com:9000/_([^/]+)',
                     http: 'http://example.com:8000/repos/{{ match[1] }}',
                     ssh: 'ssh://git@example.com:9000/_{{ match[1] }}',
                     webPattern: '^$' // This server should only match SSH remote URLs.

--- a/vscode/test/utilities.test.ts
+++ b/vscode/test/utilities.test.ts
@@ -4,7 +4,13 @@ import { expect } from 'chai';
 import assert from 'node:assert';
 import { commands, Position, Selection, Uri, window } from 'vscode';
 
-import { getSelectedRange, hasRemote, normalizeUrl, toSelection } from '../src/utilities';
+import {
+    getSelectedRange,
+    getSshUserSpecification,
+    hasRemote,
+    normalizeUrl,
+    toSelection
+} from '../src/utilities';
 
 describe('utilities', () => {
     describe('hasRemote', () => {
@@ -39,8 +45,12 @@ describe('utilities', () => {
             expect(normalizeUrl('ssh://example.com')).to.equal('example.com');
         });
 
-        it('should remove the "git@" prefix.', () => {
+        it('should remove the "git@" user specification prefix.', () => {
             expect(normalizeUrl('git@example.com')).to.equal('example.com');
+        });
+
+        it('should remove a non-standard user specification prefix.', () => {
+            expect(normalizeUrl('foo@example.com')).to.equal('example.com');
         });
 
         it('should remove the SSH prefix and the "git@" prefix.', () => {
@@ -57,6 +67,26 @@ describe('utilities', () => {
 
         it('should remove the trailing slash from SSH URLs.', () => {
             expect(normalizeUrl('ssh://example.com/')).to.equal('example.com');
+        });
+    });
+
+    describe('getSshUserSpecification', () => {
+        it('should return empty string for HTTP URLs.', () => {
+            expect(getSshUserSpecification('http://me@example.com')).to.equal('');
+        });
+
+        it('should return empty string for HTTPS URLs.', () => {
+            expect(getSshUserSpecification('https://me@example.com')).to.equal('');
+        });
+
+        ['git', 'user'].forEach((user) => {
+            it(`should return "${user}" user specification from SSH URLs with protocol.`, () => {
+                expect(getSshUserSpecification(`ssh://${user}@example.com`)).to.equal(user);
+            });
+
+            it(`should return "${user}" user specification from SSH URLs without protocol.`, () => {
+                expect(getSshUserSpecification(`${user}@example.com`)).to.equal(user);
+            });
         });
     });
 


### PR DESCRIPTION
Fixes #400

This doesn't directly fix the double-slash from #400, but it fixes the underlying problem of having to use GitHub Enterprise for a GitHub Cloud remote. The double-slash was caused by a misconfigured SSH url in the settings.