### PR TITLE
Tag support for GitHub repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.15.0 (2026-01-16)
+
+-   ⭐ GitHub Remotes: Allow tags to be selected when choosing what ref to create a link to.
+-   ⭐ VS Code: The Quick Pick for selecting the ref to create a link to now has icons.
+-   🐛 Exclude the detached HEAD from the list of branches to create a link to.
+-   🔨 Dependency updates.
+
+
 ## 2.14.1 (2026-01-16)
 
 -   🐛 Supported SSH user specifications other than "git".

--- a/build/set-version.ps1
+++ b/build/set-version.ps1
@@ -59,10 +59,10 @@ $code = Get-Content -Path $codeFileName -Raw
 $code = $code -replace "public const string Version = `"[\d.]+`";", "public const string Version = `"$($new.ToString())`";"
 Set-Content -Path $codeFileName -Value $code -NoNewLine
 
-# Set the version in the assembly info.
-$assemblyInfoFileName = Join-Path -Path $root -ChildPath "visual-studio/source/GitWebLinks/Properties/AssemblyInfo.cs"
-$assemblyInfo = Get-Content -Path $assemblyInfoFileName -Raw
-$assemblyInfo = $assemblyInfo -replace "Version\(`"[\d.]+`"\)", "Version(`"$($new.ToString()).0`")"
-Set-Content -Path $assemblyInfoFileName -Value $assemblyInfo -NoNewLine
+# Set the version in the props file.
+$propsFileName = Join-Path -Path $root -ChildPath "visual-studio/Directory.Build.props"
+$props = Get-Content -Path $propsFileName -Raw
+$props = $props -replace "<Version>[\d.]+</Version>", "<Version>$($new.ToString())</Version>"
+Set-Content -Path $propsFileName -Value $props -NoNewLine
 
 Write-Host "Done"

--- a/shared/handler-schema.json
+++ b/shared/handler-schema.json
@@ -177,6 +177,10 @@
                             "$ref": "#/definitions/urlTest",
                             "description": "A test for creating a link using the current commit hash.\n\nThe commit hash is made available to the template via the `commit` variable, and the file is always 'src/file.txt'."
                         },
+                        "tag": {
+                            "$ref": "#/definitions/urlTest",
+                            "description": "A test for creating a link using a tag.\n\nThe tag name is always 'v1.2.3', and the file is always 'src/file.txt'."
+                        },
                         "selection": {
                             "$ref": "#/definitions/selectionTests",
                             "description": "Tests for including the selected range in the URL."
@@ -470,6 +474,10 @@
             "type": "string",
             "enum": ["abbreviated", "symbolic"],
             "description": "The type of ref that is used for branch names."
+        },
+        "supportsTags": {
+            "type": "boolean",
+            "description": "Whether the handler supports creating links to tags."
         },
         "settingsKeys": {
             "type": "array",

--- a/shared/handlers/github-enterprise.json
+++ b/shared/handlers/github-enterprise.json
@@ -3,6 +3,7 @@
     "name": "GitHub Enterprise",
     "private": "gitHubEnterprise",
     "branchRef": "abbreviated",
+    "supportsTags": true,
     "url": "{{ base }}/{{ repository }}/blob/{{ ref | encode_uri }}/{{ file | encode_uri_component_segments }}",
     "query": [{ "pattern": "\\.(md|markdown)$", "key": "plain", "value": "1" }],
     "selection": "#L{{ startLine }}{% if startLine != endLine %}-L{{ endLine }}{% endif %}",
@@ -55,6 +56,10 @@
             "commit": {
                 "remote": "https://local-github.server:8080/context/foo/bar.git",
                 "result": "https://local-github.server:8080/context/foo/bar/blob/{{ commit }}/src/file.txt"
+            },
+            "tag": {
+                "remote": "https://local-github.server:8080/context/foo/bar.git",
+                "result": "https://local-github.server:8080/context/foo/bar/blob/v1.2.3/src/file.txt"
             },
             "misc": [
                 {

--- a/shared/handlers/github.json
+++ b/shared/handlers/github.json
@@ -15,6 +15,7 @@
         }
     ],
     "branchRef": "abbreviated",
+    "supportsTags": true,
     "settingsKeys": ["useGitHubDev"],
     "url": [
         "{% if useGitHubDev %}",
@@ -68,6 +69,10 @@
             "commit": {
                 "remote": "https://github.com/foo/bar.git",
                 "result": "https://github.com/foo/bar/blob/{{ commit }}/src/file.txt"
+            },
+            "tag": {
+                "remote": "https://github.com/foo/bar.git",
+                "result": "https://github.com/foo/bar/blob/v1.2.3/src/file.txt"
             },
             "misc": [
                 {

--- a/visual-studio/.editorconfig
+++ b/visual-studio/.editorconfig
@@ -251,6 +251,15 @@ dotnet_diagnostic.CA1056.severity = none
 # CA1724: Type names should not match namespaces
 dotnet_diagnostic.CA1724.severity = none
 
+# IDE0005: Using directive is unnecessary.
+dotnet_diagnostic.IDE0005.severity = warning
+
+# IDE0270: Use coalesce expression
+dotnet_diagnostic.IDE0270.severity = none
+
+# IDE0305: Simplify collection initialization
+dotnet_diagnostic.IDE0305.severity = none
+
 [*.Json*.cs]
 
 # CA1812: Avoid uninstantiated internal classes

--- a/visual-studio/Directory.Build.props
+++ b/visual-studio/Directory.Build.props
@@ -9,6 +9,7 @@
         <AnalysisMode>AllEnabledByDefault</AnalysisMode>
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
         <RootNamespace>GitWebLinks</RootNamespace>
+        <Version>2.15.0</Version>
     </PropertyGroup>
 
 </Project>

--- a/visual-studio/Directory.Build.props
+++ b/visual-studio/Directory.Build.props
@@ -7,6 +7,7 @@
         <LangVersion>13.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+        <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
         <RootNamespace>GitWebLinks</RootNamespace>
     </PropertyGroup>
 

--- a/visual-studio/source/GitWebLinks/Commands/GetLinkCommandBase.ResourceInfo.cs
+++ b/visual-studio/source/GitWebLinks/Commands/GetLinkCommandBase.ResourceInfo.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GitWebLinks;
 
 public abstract partial class GetLinkCommandBase<T> {

--- a/visual-studio/source/GitWebLinks/Commands/GetLinkCommandBase.cs
+++ b/visual-studio/source/GitWebLinks/Commands/GetLinkCommandBase.cs
@@ -1,16 +1,11 @@
-#nullable enable
-
 using Community.VisualStudio.Toolkit;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace GitWebLinks;
 

--- a/visual-studio/source/GitWebLinks/Commands/GetLinkCommands.cs
+++ b/visual-studio/source/GitWebLinks/Commands/GetLinkCommands.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using Community.VisualStudio.Toolkit;
 
 namespace GitWebLinks;

--- a/visual-studio/source/GitWebLinks/Commands/GoToFileCommand.cs
+++ b/visual-studio/source/GitWebLinks/Commands/GoToFileCommand.cs
@@ -1,11 +1,7 @@
-#nullable enable
-
 using Community.VisualStudio.Toolkit;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
-using System;
-using System.Threading.Tasks;
 
 namespace GitWebLinks;
 

--- a/visual-studio/source/GitWebLinks/GitWebLinksPackage.cs
+++ b/visual-studio/source/GitWebLinks/GitWebLinksPackage.cs
@@ -1,11 +1,7 @@
-#nullable enable
-
 using Community.VisualStudio.Toolkit;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
-using System;
 using System.Runtime.InteropServices;
-using System.Threading;
 using Task = System.Threading.Tasks.Task;
 
 namespace GitWebLinks;

--- a/visual-studio/source/GitWebLinks/Options/AzureDevOpsServer/AzureDevOpsServerOptionsPage.cs
+++ b/visual-studio/source/GitWebLinks/Options/AzureDevOpsServer/AzureDevOpsServerOptionsPage.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Runtime.InteropServices;
 using System.Windows;
 

--- a/visual-studio/source/GitWebLinks/Options/BitbucketServer/BitbucketServerOptionsPage.cs
+++ b/visual-studio/source/GitWebLinks/Options/BitbucketServer/BitbucketServerOptionsPage.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Runtime.InteropServices;
 using System.Windows;
 

--- a/visual-studio/source/GitWebLinks/Options/General/GeneralOptionsPage.cs
+++ b/visual-studio/source/GitWebLinks/Options/General/GeneralOptionsPage.cs
@@ -1,8 +1,4 @@
-#nullable enable
-
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
 using System.Runtime.InteropServices;
 using System.Windows;
 
@@ -33,17 +29,17 @@ public class GeneralOptionsPage : OptionsPageBase {
         _showOpenLinkMenuItem = false;
         _useShortHashes = false;
 
-        LinkTypes = new List<LinkTypeListItem> {
+        LinkTypes = [
             new (LinkType.Commit),
             new (LinkType.CurrentBranch),
             new (LinkType.DefaultBranch)
-        };
+        ];
 
-        LinkFormats = new List<LinkFormatListItem> {
+        LinkFormats = [
             new (LinkFormat.Raw),
             new (LinkFormat.Markdown),
             new (LinkFormat.MarkdownWithPreview)
-        };
+        ];
     }
 
 

--- a/visual-studio/source/GitWebLinks/Options/GitHub/GitHubOptionsPage.cs
+++ b/visual-studio/source/GitWebLinks/Options/GitHub/GitHubOptionsPage.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.ComponentModel;
 using System.Runtime.InteropServices;
 using System.Windows;

--- a/visual-studio/source/GitWebLinks/Options/GitHubEnterprise/GitHubEnterpriseOptionsPage.cs
+++ b/visual-studio/source/GitWebLinks/Options/GitHubEnterprise/GitHubEnterpriseOptionsPage.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Runtime.InteropServices;
 using System.Windows;
 

--- a/visual-studio/source/GitWebLinks/Options/GitLabEnterprise/GitLabEnterpriseOptionsPage.cs
+++ b/visual-studio/source/GitWebLinks/Options/GitLabEnterprise/GitLabEnterpriseOptionsPage.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Runtime.InteropServices;
 using System.Windows;
 

--- a/visual-studio/source/GitWebLinks/Options/Gitea/GiteaOptionsPage.cs
+++ b/visual-studio/source/GitWebLinks/Options/Gitea/GiteaOptionsPage.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Runtime.InteropServices;
 using System.Windows;
 

--- a/visual-studio/source/GitWebLinks/Options/Gitiles/GitilesOptionsPage.cs
+++ b/visual-studio/source/GitWebLinks/Options/Gitiles/GitilesOptionsPage.cs
@@ -1,6 +1,3 @@
-#nullable enable
-
-using System;
 using System.Runtime.InteropServices;
 using System.Windows;
 

--- a/visual-studio/source/GitWebLinks/Options/LinkFormatListItem.cs
+++ b/visual-studio/source/GitWebLinks/Options/LinkFormatListItem.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GitWebLinks;
 
 public class LinkFormatListItem {

--- a/visual-studio/source/GitWebLinks/Options/LinkTypeListItem.cs
+++ b/visual-studio/source/GitWebLinks/Options/LinkTypeListItem.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GitWebLinks;
 
 public class LinkTypeListItem {

--- a/visual-studio/source/GitWebLinks/Options/OptionsPageBase.cs
+++ b/visual-studio/source/GitWebLinks/Options/OptionsPageBase.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using Microsoft.VisualStudio.Shell;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;

--- a/visual-studio/source/GitWebLinks/Options/ServerListItem.cs
+++ b/visual-studio/source/GitWebLinks/Options/ServerListItem.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GitWebLinks;
 
 public class ServerListItem {

--- a/visual-studio/source/GitWebLinks/Options/ServerOptionsPageBase.cs
+++ b/visual-studio/source/GitWebLinks/Options/ServerOptionsPageBase.cs
@@ -1,9 +1,5 @@
-#nullable enable
-
 using Newtonsoft.Json;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
 using System.Runtime.InteropServices;
 
 namespace GitWebLinks;
@@ -11,7 +7,7 @@ namespace GitWebLinks;
 [ComVisible(true)]
 public abstract class ServerOptionsPageBase : OptionsPageBase {
 
-    private List<ServerListItem> _servers = new();
+    private List<ServerListItem> _servers = [];
 
 
     internal IReadOnlyList<StaticServer> GetServers() {
@@ -29,7 +25,7 @@ public abstract class ServerOptionsPageBase : OptionsPageBase {
     public List<ServerListItem> Servers {
         get => _servers;
         set {
-            SetProperty(ref _servers, value ?? new List<ServerListItem>());
+            SetProperty(ref _servers, value ?? []);
             OnPropertyChanged(nameof(JsonServers));
         }
     }
@@ -55,7 +51,7 @@ public abstract class ServerOptionsPageBase : OptionsPageBase {
 
     protected static List<ServerListItem> DeserializeServers(string? data) {
         if ((data is null) || (data.Length == 0)) {
-            return new List<ServerListItem>();
+            return [];
         } else {
             return JsonConvert.DeserializeObject<IEnumerable<ServerListItem>>(data).ToList();
         }

--- a/visual-studio/source/GitWebLinks/Services/Clipboard.cs
+++ b/visual-studio/source/GitWebLinks/Services/Clipboard.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Windows;
 
 namespace GitWebLinks;

--- a/visual-studio/source/GitWebLinks/Services/DefinitionProvider.Json.cs
+++ b/visual-studio/source/GitWebLinks/Services/DefinitionProvider.Json.cs
@@ -20,6 +20,9 @@ public static partial class DefinitionProvider {
         public BranchRefType BranchRef { get; set; }
 
 
+        public bool? SupportsTags { get; set; }
+
+
         public IReadOnlyList<string>? SettingsKeys { get; set; }
 
 

--- a/visual-studio/source/GitWebLinks/Services/DefinitionProvider.Json.cs
+++ b/visual-studio/source/GitWebLinks/Services/DefinitionProvider.Json.cs
@@ -1,7 +1,3 @@
-#nullable enable
-
-using System.Collections.Generic;
-
 namespace GitWebLinks;
 
 public static partial class DefinitionProvider {

--- a/visual-studio/source/GitWebLinks/Services/DefinitionProvider.ServerArrayJsonConverter.cs
+++ b/visual-studio/source/GitWebLinks/Services/DefinitionProvider.ServerArrayJsonConverter.cs
@@ -1,9 +1,5 @@
-#nullable enable
-
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using System;
-using System.Collections.Generic;
 
 namespace GitWebLinks;
 
@@ -18,7 +14,7 @@ public static partial class DefinitionProvider {
             token = JToken.Load(reader);
 
             if (token.Type == JTokenType.Object) {
-                return new JsonServer[] { token.ToObject<JsonServer>(serializer)! };
+                return [token.ToObject<JsonServer>(serializer)!];
             }
 
             return token.ToObject<IReadOnlyList<JsonServer>>();

--- a/visual-studio/source/GitWebLinks/Services/DefinitionProvider.cs
+++ b/visual-studio/source/GitWebLinks/Services/DefinitionProvider.cs
@@ -66,6 +66,7 @@ public static partial class DefinitionProvider {
             return new PrivateHandlerDefinition(
                 json.Name,
                 json.BranchRef,
+                json.SupportsTags ?? false,
                 json.SettingsKeys ?? Array.Empty<string>(),
                 parser.Parse(json.Url),
                 json.Query is not null ? ParseQueryModifications(json.Query) : Array.Empty<QueryModification>(),
@@ -78,6 +79,7 @@ public static partial class DefinitionProvider {
             return new PublicHandlerDefinition(
                 json.Name,
                 json.BranchRef,
+                json.SupportsTags ?? false,
                 json.SettingsKeys ?? Array.Empty<string>(),
                 parser.Parse(json.Url),
                 json.Query is not null ? ParseQueryModifications(json.Query) : Array.Empty<QueryModification>(),

--- a/visual-studio/source/GitWebLinks/Services/DefinitionProvider.cs
+++ b/visual-studio/source/GitWebLinks/Services/DefinitionProvider.cs
@@ -1,11 +1,6 @@
-#nullable enable
-
 using Fluid;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
 
@@ -14,10 +9,10 @@ namespace GitWebLinks;
 public static partial class DefinitionProvider {
 
     private static readonly JsonSerializerSettings SerializerSettings = new() {
-        Converters = new List<JsonConverter> {
+        Converters = [
             new StringArrayJsonConverter(),
             new ServerArrayJsonConverter()
-        }
+        ]
     };
 
 
@@ -31,7 +26,7 @@ public static partial class DefinitionProvider {
             FluidParser parser;
 
 
-            definitions = new List<HandlerDefinition>();
+            definitions = [];
             container = typeof(LinkHandlerProvider).Assembly;
             parser = new FluidParser();
 
@@ -67,9 +62,9 @@ public static partial class DefinitionProvider {
                 json.Name,
                 json.BranchRef,
                 json.SupportsTags ?? false,
-                json.SettingsKeys ?? Array.Empty<string>(),
+                json.SettingsKeys ?? [],
                 parser.Parse(json.Url),
-                json.Query is not null ? ParseQueryModifications(json.Query) : Array.Empty<QueryModification>(),
+                json.Query is not null ? ParseQueryModifications(json.Query) : [],
                 parser.Parse(json.Selection),
                 ParseReverseSettings(json.Reverse, parser),
                 json.Private
@@ -80,9 +75,9 @@ public static partial class DefinitionProvider {
                 json.Name,
                 json.BranchRef,
                 json.SupportsTags ?? false,
-                json.SettingsKeys ?? Array.Empty<string>(),
+                json.SettingsKeys ?? [],
                 parser.Parse(json.Url),
-                json.Query is not null ? ParseQueryModifications(json.Query) : Array.Empty<QueryModification>(),
+                json.Query is not null ? ParseQueryModifications(json.Query) : [],
                 parser.Parse(json.Selection),
                 ParseReverseSettings(json.Reverse, parser),
                 ParseServers(json.Server!, parser)
@@ -95,7 +90,7 @@ public static partial class DefinitionProvider {
         List<IServer> servers;
 
 
-        servers = new List<IServer>();
+        servers = [];
 
         foreach (JsonServer server in json) {
             if (server.RemotePattern is not null) {

--- a/visual-studio/source/GitWebLinks/Services/Git.cs
+++ b/visual-studio/source/GitWebLinks/Services/Git.cs
@@ -1,13 +1,8 @@
-#nullable enable
-
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace GitWebLinks;
 
@@ -52,8 +47,8 @@ public class Git {
             info.Environment["LANG"] = "C.UTF-8";
             info.Environment["LC_ALL"] = "C.UTF-8";
 
-            output = new List<string>();
-            errors = new List<string>();
+            output = [];
+            errors = [];
 
             process.StartInfo = info;
 

--- a/visual-studio/source/GitWebLinks/Services/Git.cs
+++ b/visual-studio/source/GitWebLinks/Services/Git.cs
@@ -49,6 +49,9 @@ public class Git {
                 StandardErrorEncoding = Encoding.UTF8
             };
 
+            info.Environment["LANG"] = "C.UTF-8";
+            info.Environment["LC_ALL"] = "C.UTF-8";
+
             output = new List<string>();
             errors = new List<string>();
 

--- a/visual-studio/source/GitWebLinks/Services/IClipboard.cs
+++ b/visual-studio/source/GitWebLinks/Services/IClipboard.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GitWebLinks;
 
 public interface IClipboard {

--- a/visual-studio/source/GitWebLinks/Services/ILinkHandler.cs
+++ b/visual-studio/source/GitWebLinks/Services/ILinkHandler.cs
@@ -9,6 +9,9 @@ public interface ILinkHandler {
     string Name { get; }
 
 
+    bool SupportsTags { get; }
+
+
     Task<CreateUrlResult> CreateUrlAsync(Repository repository, string remoteUrl, FileInfo file, LinkOptions options);
 
 

--- a/visual-studio/source/GitWebLinks/Services/ILinkHandler.cs
+++ b/visual-studio/source/GitWebLinks/Services/ILinkHandler.cs
@@ -1,7 +1,3 @@
-#nullable enable
-
-using System.Threading.Tasks;
-
 namespace GitWebLinks;
 
 public interface ILinkHandler {

--- a/visual-studio/source/GitWebLinks/Services/ILinkHandlerProvider.cs
+++ b/visual-studio/source/GitWebLinks/Services/ILinkHandlerProvider.cs
@@ -1,8 +1,3 @@
-#nullable enable
-
-using System.Collections.Generic;
-using System.Threading.Tasks;
-
 namespace GitWebLinks;
 
 public interface ILinkHandlerProvider {

--- a/visual-studio/source/GitWebLinks/Services/ILinkTargetLoader.cs
+++ b/visual-studio/source/GitWebLinks/Services/ILinkTargetLoader.cs
@@ -7,12 +7,6 @@ namespace GitWebLinks;
 
 public interface ILinkTargetLoader {
 
-    Task<IReadOnlyList<LinkTargetListItem>> LoadPresetsAsync();
-
-
-    Task PopulatePresetDescriptionsAsync(IEnumerable<LinkTargetListItem> presets);
-
-
-    Task<IReadOnlyList<LinkTargetListItem>> LoadRefsAsync();
+    Task<IReadOnlyList<LinkTargetListItem>> LoadAsync();
 
 }

--- a/visual-studio/source/GitWebLinks/Services/ILinkTargetLoader.cs
+++ b/visual-studio/source/GitWebLinks/Services/ILinkTargetLoader.cs
@@ -13,6 +13,6 @@ public interface ILinkTargetLoader {
     Task PopulatePresetDescriptionsAsync(IEnumerable<LinkTargetListItem> presets);
 
 
-    Task<IReadOnlyList<LinkTargetListItem>> LoadBranchesAndCommitsAsync();
+    Task<IReadOnlyList<LinkTargetListItem>> LoadRefsAsync();
 
 }

--- a/visual-studio/source/GitWebLinks/Services/ILinkTargetLoader.cs
+++ b/visual-studio/source/GitWebLinks/Services/ILinkTargetLoader.cs
@@ -1,8 +1,3 @@
-#nullable enable
-
-using System.Collections.Generic;
-using System.Threading.Tasks;
-
 namespace GitWebLinks;
 
 public interface ILinkTargetLoader {

--- a/visual-studio/source/GitWebLinks/Services/ILogger.cs
+++ b/visual-studio/source/GitWebLinks/Services/ILogger.cs
@@ -1,7 +1,3 @@
-#nullable enable
-
-using System.Threading.Tasks;
-
 namespace GitWebLinks;
 
 public interface ILogger {

--- a/visual-studio/source/GitWebLinks/Services/IRepositoryFinder.cs
+++ b/visual-studio/source/GitWebLinks/Services/IRepositoryFinder.cs
@@ -1,8 +1,3 @@
-#nullable enable
-
-using System.Collections.Generic;
-using System.Threading.Tasks;
-
 namespace GitWebLinks;
 
 public interface IRepositoryFinder {

--- a/visual-studio/source/GitWebLinks/Services/ISettings.cs
+++ b/visual-studio/source/GitWebLinks/Services/ISettings.cs
@@ -1,8 +1,3 @@
-#nullable enable
-
-using System.Collections.Generic;
-using System.Threading.Tasks;
-
 namespace GitWebLinks;
 
 public interface ISettings {

--- a/visual-studio/source/GitWebLinks/Services/LinkHandler.cs
+++ b/visual-studio/source/GitWebLinks/Services/LinkHandler.cs
@@ -36,6 +36,9 @@ public class LinkHandler : ILinkHandler {
     public string Name => _definition.Name;
 
 
+    public bool SupportsTags => _definition.SupportsTags;
+
+
     public async Task<bool> HandlesRemoteUrlAsync(string remoteUrl) {
         return await _server.MatchRemoteUrlAsync(remoteUrl) is not null;
     }
@@ -66,20 +69,32 @@ public class LinkHandler : ILinkHandler {
         // the default type that's defined in the settings.
         if (options.Target is LinkTargetPreset preset) {
             linkType = preset.Type ?? await _settings.GetDefaultLinkTypeAsync();
+            // Presets are either commits or branches.
             refType = linkType == LinkType.Commit ? RefType.Commit : RefType.Branch;
             refValue = await GetRefAsync(linkType, repository.Root, repository.Remote);
 
         } else if (options.Target is LinkTargetRef refTarget) {
-            if (refTarget.Type == RefType.Branch) {
-                refType = RefType.Branch;
-                refValue = _definition.BranchRef == BranchRefType.Abbreviated
-                    ? refTarget.RefInfo.Abbreviated
-                    : refTarget.RefInfo.Symbolic;
-            } else {
-                refType = RefType.Commit;
-                refValue = await _settings.GetUseShortHashesAsync()
-                    ? refTarget.RefInfo.Abbreviated
-                    : refTarget.RefInfo.Symbolic;
+            switch (refTarget.Type) {
+                case RefType.Branch:
+                    refType = RefType.Branch;
+                    refValue = _definition.BranchRef == BranchRefType.Abbreviated
+                        ? refTarget.RefInfo.Abbreviated
+                        : refTarget.RefInfo.Symbolic;
+                    break;
+
+                case RefType.Tag:
+                    refType = RefType.Tag;
+                    // We don't differentiate between abbreviated and symbolic
+                    // refs for tags, so just use the abbreviated ref value.
+                    refValue = refTarget.RefInfo.Abbreviated;
+                    break;
+
+                default:
+                    refType = RefType.Commit;
+                    refValue = await _settings.GetUseShortHashesAsync()
+                        ? refTarget.RefInfo.Abbreviated
+                        : refTarget.RefInfo.Symbolic;
+                    break;
             }
 
         } else {
@@ -96,7 +111,7 @@ public class LinkHandler : ILinkHandler {
             .Add("ref", refValue)
             .Add("commit", await GetRefAsync(LinkType.Commit, repository.Root, repository.Remote))
             .Add("file", relativePath)
-            .Add("type", refType == RefType.Commit ? "commit" : "branch")
+            .Add("type", refType.ToString().ToLowerInvariant())
             .Add("sshUserSpecification", UrlHelpers.GetSshUserSpecification(remoteUrl));
 
         if (file.Selection is not null) {

--- a/visual-studio/source/GitWebLinks/Services/LinkHandler.cs
+++ b/visual-studio/source/GitWebLinks/Services/LinkHandler.cs
@@ -1,15 +1,9 @@
-#nullable enable
-
 using Fluid;
 using Microsoft.VisualStudio;
-using System;
-using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.IO;
-using System.Linq;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 using System.Web;
 
 namespace GitWebLinks;
@@ -246,7 +240,7 @@ public class LinkHandler : ILinkHandler {
                     defaultBranch = await GetDefaultRemoteBranchAsync(repositoryRoot, remote);
                 }
 
-                return defaultBranch!;
+                return defaultBranch;
         }
     }
 

--- a/visual-studio/source/GitWebLinks/Services/LinkHandlerProvider.cs
+++ b/visual-studio/source/GitWebLinks/Services/LinkHandlerProvider.cs
@@ -1,9 +1,3 @@
-#nullable enable
-
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
 namespace GitWebLinks;
 
 public class LinkHandlerProvider : ILinkHandlerProvider {
@@ -66,7 +60,7 @@ public class LinkHandlerProvider : ILinkHandlerProvider {
         List<UrlInfo> output;
 
 
-        output = new List<UrlInfo>();
+        output = [];
 
         foreach (ILinkHandler handler in _handlers) {
             UrlInfo? info;

--- a/visual-studio/source/GitWebLinks/Services/LinkTargetLoader.cs
+++ b/visual-studio/source/GitWebLinks/Services/LinkTargetLoader.cs
@@ -1,10 +1,4 @@
-#nullable enable
-
 using Microsoft.VisualStudio.Imaging;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace GitWebLinks;
 
@@ -65,7 +59,7 @@ public class LinkTargetLoader : ILinkTargetLoader {
             TryGetRefAsync(LinkType.DefaultBranch)
         );
 
-        presets = new List<LinkTargetListItem>();
+        presets = [];
 
         // Omit the current branch as a preset target
         // if the current commit is a detached HEAD.
@@ -140,12 +134,12 @@ public class LinkTargetLoader : ILinkTargetLoader {
                 ),
                 _handler.SupportsTags ?
                     _git.ExecuteAsync(_repositoryRoot, "tag", "--points-at", "HEAD") :
-                    Task.FromResult<IReadOnlyList<string>>(Array.Empty<string>())
+                    Task.FromResult<IReadOnlyList<string>>([])
             );
 
-            branches = new List<LinkTargetListItem>();
-            commits = new List<LinkTargetListItem>();
-            tags = new List<LinkTargetListItem>();
+            branches = [];
+            commits = [];
+            tags = [];
             useShortHashes = await _settings.GetUseShortHashesAsync();
 
             foreach (string line in lines[0].Where((x) => x.Length > 0)) {
@@ -198,7 +192,7 @@ public class LinkTargetLoader : ILinkTargetLoader {
 
         } catch (GitCommandException ex) {
             await _logger.LogAsync($"Error while finding branch and commit link targets: {ex}");
-            return Array.Empty<LinkTargetListItem>();
+            return [];
         }
     }
 

--- a/visual-studio/source/GitWebLinks/Services/LinkTargetLoader.cs
+++ b/visual-studio/source/GitWebLinks/Services/LinkTargetLoader.cs
@@ -1,5 +1,6 @@
 #nullable enable
 
+using Microsoft.VisualStudio.Imaging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -45,14 +46,26 @@ public class LinkTargetLoader : ILinkTargetLoader {
         defaultType = await _settings.GetDefaultLinkTypeAsync();
 
         presets = new[]{
-            new LinkTargetListItem(LinkTargetListItemKind.Preset,"Current branch", new LinkTargetPreset(LinkType.CurrentBranch)),
-            new LinkTargetListItem(LinkTargetListItemKind.Preset,"Current commit", new LinkTargetPreset(LinkType.Commit)),
-            new LinkTargetListItem(LinkTargetListItemKind.Preset,"Default branch", new LinkTargetPreset(LinkType.DefaultBranch))
+            new LinkTargetListItem(
+                LinkTargetListItemKind.Preset,
+                "Current branch",
+                new LinkTargetPreset(LinkType.CurrentBranch)
+            ) { Icon = KnownMonikers.Branch },
+            new LinkTargetListItem(
+                LinkTargetListItemKind.Preset,
+                "Current commit",
+                new LinkTargetPreset(LinkType.Commit)
+            ) { Icon = KnownMonikers.Commit },
+            new LinkTargetListItem(
+                LinkTargetListItemKind.Preset,
+                "Default branch",
+                new LinkTargetPreset(LinkType.DefaultBranch)
+            ) { Icon = KnownMonikers.Branch }
         };
 
-        // Sort the default preset to the top of the list. This
-        // is done when we create the view model so that they are
-        // initially shown in the correct orderDo this first so that.
+        // Sort the default preset to the top of the list.
+        // This is done when we create the view model so that
+        // they are initially shown in the correct order.
         return presets
             .OrderByDescending((x) => ((LinkTargetPreset)x.Target).Type == defaultType)
             .ThenBy((x) => x.Name)
@@ -138,7 +151,10 @@ public class LinkTargetLoader : ILinkTargetLoader {
                         LinkTargetListItemKind.Branch,
                         parts[0],
                         new LinkTargetRef(new RefInfo(parts[0], parts[1]), RefType.Branch)
-                    ) { Description = useShortHashes ? parts[2] : parts[3] }
+                    ) {
+                        Description = useShortHashes ? parts[2] : parts[3],
+                        Icon = KnownMonikers.Branch
+                    }
                 );
 
                 commits.Add(
@@ -146,7 +162,10 @@ public class LinkTargetLoader : ILinkTargetLoader {
                         LinkTargetListItemKind.Commit,
                         useShortHashes ? parts[2] : parts[3],
                         new LinkTargetRef(new RefInfo(parts[2], parts[3]), RefType.Commit)
-                    ) { Description = parts[0] }
+                    ) {
+                        Description = parts[0],
+                        Icon = KnownMonikers.Commit
+                    }
                 );
             }
 
@@ -156,7 +175,7 @@ public class LinkTargetLoader : ILinkTargetLoader {
                         LinkTargetListItemKind.Tag,
                         line,
                         new LinkTargetRef(new RefInfo(line, line), RefType.Tag)
-                    )
+                    ) { Icon = KnownMonikers.SmartTag }
                 );
             }
 

--- a/visual-studio/source/GitWebLinks/Services/LinkTargetLoader.cs
+++ b/visual-studio/source/GitWebLinks/Services/LinkTargetLoader.cs
@@ -38,44 +38,26 @@ public class LinkTargetLoader : ILinkTargetLoader {
     }
 
 
-    public async Task<IReadOnlyList<LinkTargetListItem>> LoadPresetsAsync() {
-        LinkType defaultType;
-        IEnumerable<LinkTargetListItem> presets;
+    public async Task<IReadOnlyList<LinkTargetListItem>> LoadAsync() {
+        IReadOnlyList<LinkTargetListItem>[] items;
 
 
-        defaultType = await _settings.GetDefaultLinkTypeAsync();
+        items = await Task.WhenAll(
+            LoadPresetsAsync(),
+            LoadRefsAsync()
+        );
 
-        presets = new[]{
-            new LinkTargetListItem(
-                LinkTargetListItemKind.Preset,
-                "Current branch",
-                new LinkTargetPreset(LinkType.CurrentBranch)
-            ) { Icon = KnownMonikers.Branch },
-            new LinkTargetListItem(
-                LinkTargetListItemKind.Preset,
-                "Current commit",
-                new LinkTargetPreset(LinkType.Commit)
-            ) { Icon = KnownMonikers.Commit },
-            new LinkTargetListItem(
-                LinkTargetListItemKind.Preset,
-                "Default branch",
-                new LinkTargetPreset(LinkType.DefaultBranch)
-            ) { Icon = KnownMonikers.Branch }
-        };
-
-        // Sort the default preset to the top of the list.
-        // This is done when we create the view model so that
-        // they are initially shown in the correct order.
-        return presets
-            .OrderByDescending((x) => ((LinkTargetPreset)x.Target).Type == defaultType)
-            .ThenBy((x) => x.Name)
-            .ToList();
+        return items.SelectMany((x) => x).ToList();
     }
 
 
-    public async Task PopulatePresetDescriptionsAsync(IEnumerable<LinkTargetListItem> presets) {
+    private async Task<IReadOnlyList<LinkTargetListItem>> LoadPresetsAsync() {
+        LinkType defaultType;
         string[] descriptions;
+        List<LinkTargetListItem> presets;
 
+
+        defaultType = await _settings.GetDefaultLinkTypeAsync();
 
         descriptions = await Task.WhenAll(
             TryGetRefAsync(LinkType.CurrentBranch),
@@ -83,21 +65,47 @@ public class LinkTargetLoader : ILinkTargetLoader {
             TryGetRefAsync(LinkType.DefaultBranch)
         );
 
-        foreach (LinkTargetListItem preset in presets) {
-            switch (((LinkTargetPreset)preset.Target).Type) {
-                case LinkType.CurrentBranch:
-                    preset.Description = descriptions[0];
-                    break;
+        presets = new List<LinkTargetListItem>();
 
-                case LinkType.Commit:
-                    preset.Description = descriptions[1];
-                    break;
-
-                case LinkType.DefaultBranch:
-                    preset.Description = descriptions[2];
-                    break;
-            }
+        // Omit the current branch as a preset target
+        // if the current commit is a detached HEAD.
+        if (descriptions[0] != "HEAD") {
+            presets.Add(
+                new LinkTargetListItem(
+                    LinkTargetListItemKind.Preset,
+                    "Current branch",
+                    descriptions[0],
+                    KnownMonikers.Branch,
+                    new LinkTargetPreset(LinkType.CurrentBranch)
+                )
+            );
         }
+
+        presets.Add(
+            new LinkTargetListItem(
+                LinkTargetListItemKind.Preset,
+                "Current commit",
+                descriptions[1],
+                KnownMonikers.Commit,
+                new LinkTargetPreset(LinkType.Commit)
+            )
+        );
+
+        presets.Add(
+            new LinkTargetListItem(
+                LinkTargetListItemKind.Preset,
+                "Default branch",
+                descriptions[2],
+                KnownMonikers.Branch,
+                new LinkTargetPreset(LinkType.DefaultBranch)
+            )
+        );
+
+        // Sort the default preset to the top of the list.
+        return presets
+            .OrderByDescending((x) => ((LinkTargetPreset)x.Target).Type == defaultType)
+            .ThenBy((x) => x.Name)
+            .ToList();
     }
 
 
@@ -112,7 +120,7 @@ public class LinkTargetLoader : ILinkTargetLoader {
     }
 
 
-    public async Task<IReadOnlyList<LinkTargetListItem>> LoadRefsAsync() {
+    private async Task<IReadOnlyList<LinkTargetListItem>> LoadRefsAsync() {
         try {
             IReadOnlyList<string>[] lines;
             List<LinkTargetListItem> branches;
@@ -128,7 +136,7 @@ public class LinkTargetLoader : ILinkTargetLoader {
                     "--list",
                     "--no-color",
                     "--format",
-                    "\"%(refname:short) %(refname) %(objectname:short) %(objectname)\""
+                    "\"%(refname:short)~%(refname)~%(objectname:short)~%(objectname)\""
                 ),
                 _handler.SupportsTags ?
                     _git.ExecuteAsync(_repositoryRoot, "tag", "--points-at", "HEAD") :
@@ -144,28 +152,29 @@ public class LinkTargetLoader : ILinkTargetLoader {
                 string[] parts;
 
 
-                parts = line.Split(' ');
+                parts = line.Split('~');
 
-                branches.Add(
-                    new LinkTargetListItem(
-                        LinkTargetListItemKind.Branch,
-                        parts[0],
-                        new LinkTargetRef(new RefInfo(parts[0], parts[1]), RefType.Branch)
-                    ) {
-                        Description = useShortHashes ? parts[2] : parts[3],
-                        Icon = KnownMonikers.Branch
-                    }
-                );
+                // Omit the branch item for a detached HEAD, but include the commit.
+                if (!parts[0].StartsWith("(HEAD detached", StringComparison.Ordinal)) {
+                    branches.Add(
+                        new LinkTargetListItem(
+                            LinkTargetListItemKind.Branch,
+                            parts[0],
+                            useShortHashes ? parts[2] : parts[3],
+                            KnownMonikers.Branch,
+                            new LinkTargetRef(new RefInfo(parts[0], parts[1]), RefType.Branch)
+                        )
+                    );
+                }
 
                 commits.Add(
                     new LinkTargetListItem(
                         LinkTargetListItemKind.Commit,
                         useShortHashes ? parts[2] : parts[3],
+                        parts[0],
+                        KnownMonikers.Commit,
                         new LinkTargetRef(new RefInfo(parts[2], parts[3]), RefType.Commit)
-                    ) {
-                        Description = parts[0],
-                        Icon = KnownMonikers.Commit
-                    }
+                    )
                 );
             }
 
@@ -174,8 +183,10 @@ public class LinkTargetLoader : ILinkTargetLoader {
                     new LinkTargetListItem(
                         LinkTargetListItemKind.Tag,
                         line,
+                        "",
+                        KnownMonikers.SmartTag,
                         new LinkTargetRef(new RefInfo(line, line), RefType.Tag)
-                    ) { Icon = KnownMonikers.SmartTag }
+                    )
                 );
             }
 

--- a/visual-studio/source/GitWebLinks/Services/LinkTargetLoader.cs
+++ b/visual-studio/source/GitWebLinks/Services/LinkTargetLoader.cs
@@ -99,28 +99,35 @@ public class LinkTargetLoader : ILinkTargetLoader {
     }
 
 
-    public async Task<IReadOnlyList<LinkTargetListItem>> LoadBranchesAndCommitsAsync() {
+    public async Task<IReadOnlyList<LinkTargetListItem>> LoadRefsAsync() {
         try {
-            IReadOnlyList<string> lines;
+            IReadOnlyList<string>[] lines;
             List<LinkTargetListItem> branches;
             List<LinkTargetListItem> commits;
+            List<LinkTargetListItem> tags;
             bool useShortHashes;
 
 
-            lines = await _git.ExecuteAsync(
-                _repositoryRoot,
-                "branch",
-                "--list",
-                "--no-color",
-                "--format",
-                "\"%(refname:short) %(refname) %(objectname:short) %(objectname)\""
+            lines = await Task.WhenAll(
+                _git.ExecuteAsync(
+                    _repositoryRoot,
+                    "branch",
+                    "--list",
+                    "--no-color",
+                    "--format",
+                    "\"%(refname:short) %(refname) %(objectname:short) %(objectname)\""
+                ),
+                _handler.SupportsTags ?
+                    _git.ExecuteAsync(_repositoryRoot, "tag", "--points-at", "HEAD") :
+                    Task.FromResult<IReadOnlyList<string>>(Array.Empty<string>())
             );
 
             branches = new List<LinkTargetListItem>();
             commits = new List<LinkTargetListItem>();
+            tags = new List<LinkTargetListItem>();
             useShortHashes = await _settings.GetUseShortHashesAsync();
 
-            foreach (string line in lines.Where((x) => x.Length > 0)) {
+            foreach (string line in lines[0].Where((x) => x.Length > 0)) {
                 string[] parts;
 
 
@@ -143,10 +150,21 @@ public class LinkTargetLoader : ILinkTargetLoader {
                 );
             }
 
+            foreach (string line in lines[1].Where((x) => x.Length > 0)) {
+                tags.Add(
+                    new LinkTargetListItem(
+                        LinkTargetListItemKind.Tag,
+                        line,
+                        new LinkTargetRef(new RefInfo(line, line), RefType.Tag)
+                    )
+                );
+            }
+
             branches.Sort((x, y) => string.Compare(x.Name, y.Name, true));
             commits.Sort((x, y) => string.Compare(x.Name, y.Name, true));
+            tags.Sort((x, y) => string.Compare(x.Name, y.Name, true));
 
-            return branches.Concat(commits).ToList();
+            return branches.Concat(commits).Concat(tags).ToList();
 
         } catch (GitCommandException ex) {
             await _logger.LogAsync($"Error while finding branch and commit link targets: {ex}");

--- a/visual-studio/source/GitWebLinks/Services/LinkTargetSelector.cs
+++ b/visual-studio/source/GitWebLinks/Services/LinkTargetSelector.cs
@@ -1,9 +1,6 @@
-#nullable enable
-
 using Community.VisualStudio.Toolkit;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text.PatternMatching;
-using System.Threading.Tasks;
 
 namespace GitWebLinks;
 
@@ -26,7 +23,7 @@ public class LinkTargetSelector {
         SelectTargetDialog dialog;
 
 
-        viewModel = await SelectTargetDialogViewModel.CreateAsync(
+        viewModel = new SelectTargetDialogViewModel(
             new LinkTargetLoader(_settings, _git, handler, repository, _logger),
             await VS.GetMefServiceAsync<IPatternMatcherFactory>(),
             ThreadHelper.JoinableTaskFactory

--- a/visual-studio/source/GitWebLinks/Services/Logger.cs
+++ b/visual-studio/source/GitWebLinks/Services/Logger.cs
@@ -1,7 +1,4 @@
-#nullable enable
-
 using Community.VisualStudio.Toolkit;
-using System.Threading.Tasks;
 
 namespace GitWebLinks;
 

--- a/visual-studio/source/GitWebLinks/Services/RepositoryFinder.cs
+++ b/visual-studio/source/GitWebLinks/Services/RepositoryFinder.cs
@@ -1,10 +1,4 @@
-#nullable enable
-
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace GitWebLinks;
 
@@ -12,7 +6,7 @@ namespace GitWebLinks;
 public class RepositoryFinder : IRepositoryFinder {
 
     private static readonly HashSet<string> IgnoredDirectories = new(
-        new[] { "node_modules", "bin", "obj" },
+        ["node_modules", "bin", "obj"],
         StringComparer.OrdinalIgnoreCase
     );
 
@@ -75,7 +69,7 @@ public class RepositoryFinder : IRepositoryFinder {
             )
             .Select((entry) => entry.FullName);
 
-        descendInto = new List<string>();
+        descendInto = [];
 
         // Yield any direct child that is a repository root. Any other directories
         // can be descended into, but we'll look at all direct children first.

--- a/visual-studio/source/GitWebLinks/Services/Settings.cs
+++ b/visual-studio/source/GitWebLinks/Services/Settings.cs
@@ -1,10 +1,5 @@
-#nullable enable
-
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 
 namespace GitWebLinks;
 
@@ -17,7 +12,7 @@ public class Settings : ISettings {
 
     public Settings(AsyncPackage package) {
         _generalOptions = new AsyncLazy<GeneralOptionsPage>(
-            () => package.GetDialogPageAsync<GeneralOptionsPage>(),
+            package.GetDialogPageAsync<GeneralOptionsPage>,
             joinableTaskFactory: package.JoinableTaskFactory
         );
 
@@ -75,7 +70,7 @@ public class Settings : ISettings {
             return await provider.GetServersAsync();
         }
 
-        return Array.Empty<StaticServer>();
+        return [];
     }
 
 
@@ -116,7 +111,7 @@ public class Settings : ISettings {
             _valueProvider = valueProvider;
 
             _dialogPage = new AsyncLazy<T>(
-                () => package.GetDialogPageAsync<T>(),
+                package.GetDialogPageAsync<T>,
                 joinableTaskFactory: package.JoinableTaskFactory
             );
         }

--- a/visual-studio/source/GitWebLinks/Services/TemplateData.cs
+++ b/visual-studio/source/GitWebLinks/Services/TemplateData.cs
@@ -1,8 +1,4 @@
-#nullable enable
-
 using Fluid;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace GitWebLinks;
@@ -34,8 +30,8 @@ public class TemplateData {
             Dictionary<string, object?> groupsData;
 
 
-            matchData = new Dictionary<string, object?>();
-            groupsData = new Dictionary<string, object?>();
+            matchData = [];
+            groupsData = [];
 
             foreach (Group group in match.Groups.OfType<Group>()) {
                 groupsData[group.Name] = group.Success ? group.Value : null;

--- a/visual-studio/source/GitWebLinks/Services/TemplateEngine.cs
+++ b/visual-studio/source/GitWebLinks/Services/TemplateEngine.cs
@@ -1,12 +1,7 @@
-#nullable enable
-
 using Fluid;
 using Fluid.Values;
-using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace GitWebLinks;
 

--- a/visual-studio/source/GitWebLinks/Types/BranchRefType.cs
+++ b/visual-studio/source/GitWebLinks/Types/BranchRefType.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GitWebLinks;
 
 public enum BranchRefType {

--- a/visual-studio/source/GitWebLinks/Types/CommandLinkType.cs
+++ b/visual-studio/source/GitWebLinks/Types/CommandLinkType.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GitWebLinks;
 
 public enum CommandLinkType {

--- a/visual-studio/source/GitWebLinks/Types/CreateUrlResult.cs
+++ b/visual-studio/source/GitWebLinks/Types/CreateUrlResult.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GitWebLinks;
 
 public class CreateUrlResult {

--- a/visual-studio/source/GitWebLinks/Types/DynamicServer.cs
+++ b/visual-studio/source/GitWebLinks/Types/DynamicServer.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using Fluid;
 using System.Text.RegularExpressions;
 

--- a/visual-studio/source/GitWebLinks/Types/FileInfo.cs
+++ b/visual-studio/source/GitWebLinks/Types/FileInfo.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GitWebLinks;
 
 public class FileInfo {

--- a/visual-studio/source/GitWebLinks/Types/GitCommandException.cs
+++ b/visual-studio/source/GitWebLinks/Types/GitCommandException.cs
@@ -1,6 +1,3 @@
-#nullable enable
-
-using System;
 using System.Runtime.Serialization;
 
 namespace GitWebLinks;

--- a/visual-studio/source/GitWebLinks/Types/GitNotFoundException.cs
+++ b/visual-studio/source/GitWebLinks/Types/GitNotFoundException.cs
@@ -1,6 +1,3 @@
-#nullable enable
-
-using System;
 using System.Runtime.Serialization;
 
 namespace GitWebLinks;

--- a/visual-studio/source/GitWebLinks/Types/HandlerDefinition.cs
+++ b/visual-studio/source/GitWebLinks/Types/HandlerDefinition.cs
@@ -10,6 +10,7 @@ public class HandlerDefinition {
     public HandlerDefinition(
         string name,
         BranchRefType branchRef,
+        bool supportsTags,
         IReadOnlyList<string> settingsKeys,
         IFluidTemplate url,
         IReadOnlyList<QueryModification> query,
@@ -18,6 +19,7 @@ public class HandlerDefinition {
     ) {
         Name = name;
         BranchRef = branchRef;
+        SupportsTags = supportsTags;
         SettingsKeys = settingsKeys;
         Url = url;
         Query = query;
@@ -30,6 +32,9 @@ public class HandlerDefinition {
 
 
     public BranchRefType BranchRef { get; }
+
+
+    public bool SupportsTags { get; }
 
 
     public IReadOnlyList<string> SettingsKeys { get; }

--- a/visual-studio/source/GitWebLinks/Types/HandlerDefinition.cs
+++ b/visual-studio/source/GitWebLinks/Types/HandlerDefinition.cs
@@ -1,7 +1,4 @@
-#nullable enable
-
 using Fluid;
-using System.Collections.Generic;
 
 namespace GitWebLinks;
 

--- a/visual-studio/source/GitWebLinks/Types/ILinkTarget.cs
+++ b/visual-studio/source/GitWebLinks/Types/ILinkTarget.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GitWebLinks;
 
 public interface ILinkTarget {

--- a/visual-studio/source/GitWebLinks/Types/IServer.cs
+++ b/visual-studio/source/GitWebLinks/Types/IServer.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GitWebLinks;
 
 public interface IServer { }

--- a/visual-studio/source/GitWebLinks/Types/LinkFormat.cs
+++ b/visual-studio/source/GitWebLinks/Types/LinkFormat.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GitWebLinks;
 
 public enum LinkFormat {

--- a/visual-studio/source/GitWebLinks/Types/LinkOptions.cs
+++ b/visual-studio/source/GitWebLinks/Types/LinkOptions.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GitWebLinks;
 
 public class LinkOptions {

--- a/visual-studio/source/GitWebLinks/Types/LinkTargetPreset.cs
+++ b/visual-studio/source/GitWebLinks/Types/LinkTargetPreset.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GitWebLinks;
 
 public class LinkTargetPreset : ILinkTarget {

--- a/visual-studio/source/GitWebLinks/Types/LinkTargetRef.cs
+++ b/visual-studio/source/GitWebLinks/Types/LinkTargetRef.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GitWebLinks;
 
 public class LinkTargetRef : ILinkTarget {

--- a/visual-studio/source/GitWebLinks/Types/LinkType.cs
+++ b/visual-studio/source/GitWebLinks/Types/LinkType.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GitWebLinks;
 
 public enum LinkType {

--- a/visual-studio/source/GitWebLinks/Types/NoRemoteHeadException.cs
+++ b/visual-studio/source/GitWebLinks/Types/NoRemoteHeadException.cs
@@ -1,6 +1,3 @@
-#nullable enable
-
-using System;
 using System.Runtime.Serialization;
 
 namespace GitWebLinks;

--- a/visual-studio/source/GitWebLinks/Types/PartialSelectedRange.cs
+++ b/visual-studio/source/GitWebLinks/Types/PartialSelectedRange.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Text;
 
 namespace GitWebLinks;

--- a/visual-studio/source/GitWebLinks/Types/PrivateHandlerDefinition.cs
+++ b/visual-studio/source/GitWebLinks/Types/PrivateHandlerDefinition.cs
@@ -1,7 +1,4 @@
-#nullable enable
-
 using Fluid;
-using System.Collections.Generic;
 
 namespace GitWebLinks;
 

--- a/visual-studio/source/GitWebLinks/Types/PrivateHandlerDefinition.cs
+++ b/visual-studio/source/GitWebLinks/Types/PrivateHandlerDefinition.cs
@@ -10,13 +10,14 @@ public class PrivateHandlerDefinition : HandlerDefinition {
     public PrivateHandlerDefinition(
         string name,
         BranchRefType branchRef,
+        bool supportsTags,
         IReadOnlyList<string> settingsKeys,
         IFluidTemplate url,
         IReadOnlyList<QueryModification> query,
         IFluidTemplate selection,
         ReverseSettings reverse,
         string serverSettingsKey
-    ) : base(name, branchRef, settingsKeys, url, query, selection, reverse) {
+    ) : base(name, branchRef, supportsTags, settingsKeys, url, query, selection, reverse) {
         ServerSettingsKey = serverSettingsKey;
     }
 

--- a/visual-studio/source/GitWebLinks/Types/PublicHandlerDefinition.cs
+++ b/visual-studio/source/GitWebLinks/Types/PublicHandlerDefinition.cs
@@ -1,7 +1,4 @@
-#nullable enable
-
 using Fluid;
-using System.Collections.Generic;
 
 namespace GitWebLinks;
 

--- a/visual-studio/source/GitWebLinks/Types/PublicHandlerDefinition.cs
+++ b/visual-studio/source/GitWebLinks/Types/PublicHandlerDefinition.cs
@@ -10,13 +10,14 @@ public class PublicHandlerDefinition : HandlerDefinition {
     public PublicHandlerDefinition(
         string name,
         BranchRefType branchRef,
+        bool supportsTags,
         IReadOnlyList<string> settingsKeys,
         IFluidTemplate url,
         IReadOnlyList<QueryModification> query,
         IFluidTemplate selection,
         ReverseSettings reverse,
         IReadOnlyList<IServer> servers
-    ) : base(name, branchRef, settingsKeys, url, query, selection, reverse) {
+    ) : base(name, branchRef, supportsTags, settingsKeys, url, query, selection, reverse) {
         Servers = servers;
     }
 

--- a/visual-studio/source/GitWebLinks/Types/QueryModification.cs
+++ b/visual-studio/source/GitWebLinks/Types/QueryModification.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Text.RegularExpressions;
 
 namespace GitWebLinks;

--- a/visual-studio/source/GitWebLinks/Types/RefInfo.cs
+++ b/visual-studio/source/GitWebLinks/Types/RefInfo.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GitWebLinks;
 
 public class RefInfo {

--- a/visual-studio/source/GitWebLinks/Types/RefType.cs
+++ b/visual-studio/source/GitWebLinks/Types/RefType.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GitWebLinks;
 
 public enum RefType {

--- a/visual-studio/source/GitWebLinks/Types/RefType.cs
+++ b/visual-studio/source/GitWebLinks/Types/RefType.cs
@@ -4,5 +4,6 @@ namespace GitWebLinks;
 
 public enum RefType {
     Commit,
-    Branch
+    Branch,
+    Tag
 }

--- a/visual-studio/source/GitWebLinks/Types/Remote.cs
+++ b/visual-studio/source/GitWebLinks/Types/Remote.cs
@@ -1,8 +1,3 @@
-#nullable enable
-
-using System.Collections.Generic;
-using System.Linq;
-
 namespace GitWebLinks;
 
 public class Remote {

--- a/visual-studio/source/GitWebLinks/Types/RemoteServer.cs
+++ b/visual-studio/source/GitWebLinks/Types/RemoteServer.cs
@@ -1,11 +1,5 @@
-#nullable enable
-
 using Fluid;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
 namespace GitWebLinks;
 
@@ -15,17 +9,17 @@ public class RemoteServer {
 
 
     public RemoteServer(IServer server) {
-        _matchers = new List<Matcher> { CreateMatcher(server) };
+        _matchers = [CreateMatcher(server)];
     }
 
 
     public RemoteServer(IEnumerable<IServer> servers) {
-        _matchers = servers.Select((x) => CreateMatcher(x)).ToList();
+        _matchers = servers.Select(CreateMatcher).ToList();
     }
 
 
     public RemoteServer(Func<Task<IEnumerable<StaticServer>>> serverFactory) {
-        _matchers = new List<Matcher> { CreateLazyStaticServerMatcher(serverFactory) };
+        _matchers = [CreateLazyStaticServerMatcher(serverFactory)];
     }
 
 

--- a/visual-studio/source/GitWebLinks/Types/Repository.cs
+++ b/visual-studio/source/GitWebLinks/Types/Repository.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GitWebLinks;
 
 public class Repository {

--- a/visual-studio/source/GitWebLinks/Types/ReverseSelectionSettings.cs
+++ b/visual-studio/source/GitWebLinks/Types/ReverseSelectionSettings.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using Fluid;
 
 namespace GitWebLinks;

--- a/visual-studio/source/GitWebLinks/Types/ReverseServerSettings.cs
+++ b/visual-studio/source/GitWebLinks/Types/ReverseServerSettings.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using Fluid;
 
 namespace GitWebLinks;

--- a/visual-studio/source/GitWebLinks/Types/ReverseSettings.cs
+++ b/visual-studio/source/GitWebLinks/Types/ReverseSettings.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using Fluid;
 using System.Text.RegularExpressions;
 

--- a/visual-studio/source/GitWebLinks/Types/SelectedLinkHandler.cs
+++ b/visual-studio/source/GitWebLinks/Types/SelectedLinkHandler.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using GitWebLinks;
 
 public class SelectedLinkHandler {

--- a/visual-studio/source/GitWebLinks/Types/SelectedRange.cs
+++ b/visual-studio/source/GitWebLinks/Types/SelectedRange.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GitWebLinks;
 
 public class SelectedRange {

--- a/visual-studio/source/GitWebLinks/Types/StaticServer.cs
+++ b/visual-studio/source/GitWebLinks/Types/StaticServer.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Text;
 
 namespace GitWebLinks;

--- a/visual-studio/source/GitWebLinks/Types/UrlInfo.cs
+++ b/visual-studio/source/GitWebLinks/Types/UrlInfo.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GitWebLinks;
 
 public class UrlInfo {

--- a/visual-studio/source/GitWebLinks/UI/AttachedProperties/CancelOnEscape.cs
+++ b/visual-studio/source/GitWebLinks/UI/AttachedProperties/CancelOnEscape.cs
@@ -1,6 +1,3 @@
-#nullable enable
-
-using System;
 using System.Windows;
 using System.Windows.Input;
 

--- a/visual-studio/source/GitWebLinks/UI/AttachedProperties/CancelOnLostKeyboardFocus.cs
+++ b/visual-studio/source/GitWebLinks/UI/AttachedProperties/CancelOnLostKeyboardFocus.cs
@@ -1,6 +1,3 @@
-#nullable enable
-
-using System;
 using System.Windows;
 
 namespace GitWebLinks;

--- a/visual-studio/source/GitWebLinks/UI/AttachedProperties/ClearOnEscape.cs
+++ b/visual-studio/source/GitWebLinks/UI/AttachedProperties/ClearOnEscape.cs
@@ -1,6 +1,3 @@
-#nullable enable
-
-using System;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;

--- a/visual-studio/source/GitWebLinks/UI/AttachedProperties/CloseSignal.cs
+++ b/visual-studio/source/GitWebLinks/UI/AttachedProperties/CloseSignal.cs
@@ -1,6 +1,3 @@
-#nullable enable
-
-using System;
 using System.Windows;
 
 namespace GitWebLinks;

--- a/visual-studio/source/GitWebLinks/UI/AttachedProperties/DialogResult.cs
+++ b/visual-studio/source/GitWebLinks/UI/AttachedProperties/DialogResult.cs
@@ -1,6 +1,3 @@
-#nullable enable
-
-using System;
 using System.Windows;
 
 namespace GitWebLinks;

--- a/visual-studio/source/GitWebLinks/UI/AttachedProperties/FocusOnLoad.cs
+++ b/visual-studio/source/GitWebLinks/UI/AttachedProperties/FocusOnLoad.cs
@@ -1,7 +1,4 @@
-#nullable enable
-
 using Microsoft.VisualStudio;
-using System;
 using System.Diagnostics;
 using System.Windows;
 

--- a/visual-studio/source/GitWebLinks/UI/AttachedProperties/ListNavigation.cs
+++ b/visual-studio/source/GitWebLinks/UI/AttachedProperties/ListNavigation.cs
@@ -1,6 +1,3 @@
-#nullable enable
-
-using System;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;

--- a/visual-studio/source/GitWebLinks/UI/AttachedProperties/SelectAllOnFocus.cs
+++ b/visual-studio/source/GitWebLinks/UI/AttachedProperties/SelectAllOnFocus.cs
@@ -1,6 +1,3 @@
-#nullable enable
-
-using System;
 using System.Windows;
 using System.Windows.Controls.Primitives;
 

--- a/visual-studio/source/GitWebLinks/UI/Controls/ServerDataGrid.cs
+++ b/visual-studio/source/GitWebLinks/UI/Controls/ServerDataGrid.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;

--- a/visual-studio/source/GitWebLinks/UI/Windows/GoToFileDialog/FileTarget.cs
+++ b/visual-studio/source/GitWebLinks/UI/Windows/GoToFileDialog/FileTarget.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GitWebLinks;
 
 public class FileTarget {

--- a/visual-studio/source/GitWebLinks/UI/Windows/GoToFileDialog/FileTargetListItem.cs
+++ b/visual-studio/source/GitWebLinks/UI/Windows/GoToFileDialog/FileTargetListItem.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using Microsoft.VisualStudio.Imaging.Interop;
 using System.IO;
 

--- a/visual-studio/source/GitWebLinks/UI/Windows/GoToFileDialog/GoToFileDialogViewModel.cs
+++ b/visual-studio/source/GitWebLinks/UI/Windows/GoToFileDialog/GoToFileDialogViewModel.cs
@@ -1,16 +1,9 @@
-#nullable enable
-
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using System.Windows;
 
 namespace GitWebLinks;

--- a/visual-studio/source/GitWebLinks/UI/Windows/SelectTargetDialog/LinkTargetListItem.cs
+++ b/visual-studio/source/GitWebLinks/UI/Windows/SelectTargetDialog/LinkTargetListItem.cs
@@ -1,5 +1,6 @@
 #nullable enable
 
+using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Text;
 using System.Collections.Immutable;
@@ -9,6 +10,7 @@ namespace GitWebLinks;
 public class LinkTargetListItem : ObservableObject {
 
     private string _description;
+    private ImageMoniker _icon;
     private ImmutableArray<Span> _nameHighlightSpans;
     private ImmutableArray<Span> _descriptionHighlightSpans;
 
@@ -35,6 +37,12 @@ public class LinkTargetListItem : ObservableObject {
     public string Description {
         get => _description;
         set => SetProperty(ref _description, value);
+    }
+
+
+    public ImageMoniker Icon {
+        get => _icon;
+        set => SetProperty(ref _icon, value);
     }
 
 

--- a/visual-studio/source/GitWebLinks/UI/Windows/SelectTargetDialog/LinkTargetListItem.cs
+++ b/visual-studio/source/GitWebLinks/UI/Windows/SelectTargetDialog/LinkTargetListItem.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Text;

--- a/visual-studio/source/GitWebLinks/UI/Windows/SelectTargetDialog/LinkTargetListItem.cs
+++ b/visual-studio/source/GitWebLinks/UI/Windows/SelectTargetDialog/LinkTargetListItem.cs
@@ -9,17 +9,22 @@ namespace GitWebLinks;
 
 public class LinkTargetListItem : ObservableObject {
 
-    private string _description;
-    private ImageMoniker _icon;
     private ImmutableArray<Span> _nameHighlightSpans;
     private ImmutableArray<Span> _descriptionHighlightSpans;
 
 
-    public LinkTargetListItem(LinkTargetListItemKind kind, string name, ILinkTarget target) {
+    public LinkTargetListItem(
+        LinkTargetListItemKind kind,
+        string name,
+        string description,
+        ImageMoniker icon,
+        ILinkTarget target
+    ) {
         Kind = kind;
         Name = name;
+        Description = description;
+        Icon = icon;
         Target = target;
-        _description = "";
         _nameHighlightSpans = ImmutableArray<Span>.Empty;
         _descriptionHighlightSpans = ImmutableArray<Span>.Empty;
     }
@@ -34,16 +39,10 @@ public class LinkTargetListItem : ObservableObject {
     public ILinkTarget Target { get; }
 
 
-    public string Description {
-        get => _description;
-        set => SetProperty(ref _description, value);
-    }
+    public string Description { get; }
 
 
-    public ImageMoniker Icon {
-        get => _icon;
-        set => SetProperty(ref _icon, value);
-    }
+    public ImageMoniker Icon { get; }
 
 
     public ImmutableArray<Span> NameHighlightSpans {

--- a/visual-studio/source/GitWebLinks/UI/Windows/SelectTargetDialog/LinkTargetListItemKind.cs
+++ b/visual-studio/source/GitWebLinks/UI/Windows/SelectTargetDialog/LinkTargetListItemKind.cs
@@ -5,5 +5,6 @@ namespace GitWebLinks;
 public enum LinkTargetListItemKind {
     Preset,
     Branch,
-    Commit
+    Commit,
+    Tag
 }

--- a/visual-studio/source/GitWebLinks/UI/Windows/SelectTargetDialog/LinkTargetListItemKind.cs
+++ b/visual-studio/source/GitWebLinks/UI/Windows/SelectTargetDialog/LinkTargetListItemKind.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GitWebLinks;
 
 public enum LinkTargetListItemKind {

--- a/visual-studio/source/GitWebLinks/UI/Windows/SelectTargetDialog/SelectTargetDialog.xaml
+++ b/visual-studio/source/GitWebLinks/UI/Windows/SelectTargetDialog/SelectTargetDialog.xaml
@@ -191,6 +191,15 @@
                 Margin="7"
                 />
 
+            <TextBlock
+                Grid.Row="1"
+                VerticalAlignment="Top"
+                TextAlignment="Center"
+                Text="Loading link targets..."
+                Visibility="{Binding LoadingVisibility}"
+                Margin="7"
+                />
+            
             <platform:SmoothProgressBar
                 Grid.Row="1"
                 IsIndeterminate="True"

--- a/visual-studio/source/GitWebLinks/UI/Windows/SelectTargetDialog/SelectTargetDialog.xaml
+++ b/visual-studio/source/GitWebLinks/UI/Windows/SelectTargetDialog/SelectTargetDialog.xaml
@@ -147,7 +147,7 @@
                                 <imaging:CrispImage
                                     Grid.Column="0"
                                     x:Name="TargetIcon"
-                                    Moniker="{x:Static catalog:KnownMonikers.PushPin}"
+                                    Moniker="{Binding Icon}"
                                     Margin="3"
                                     VerticalAlignment="Center"
                                     />
@@ -178,16 +178,6 @@
                                     />
                             </Grid>
                         </Border>
-
-                        <DataTemplate.Triggers>
-                            <DataTrigger Binding="{Binding Kind}" Value="{x:Static local:LinkTargetListItemKind.Commit}">
-                                <Setter TargetName="TargetIcon" Property="Moniker" Value="{x:Static catalog:KnownMonikers.Commit}"/>
-                            </DataTrigger>
-
-                            <DataTrigger Binding="{Binding Kind}" Value="{x:Static local:LinkTargetListItemKind.Branch}">
-                                <Setter TargetName="TargetIcon" Property="Moniker" Value="{x:Static catalog:KnownMonikers.Branch}"/>
-                            </DataTrigger>
-                        </DataTemplate.Triggers>
                     </DataTemplate>
                 </ListBox.ItemTemplate>
             </ListBox>

--- a/visual-studio/source/GitWebLinks/UI/Windows/SelectTargetDialog/SelectTargetDialogViewModel.cs
+++ b/visual-studio/source/GitWebLinks/UI/Windows/SelectTargetDialog/SelectTargetDialogViewModel.cs
@@ -1,17 +1,11 @@
-#nullable enable
-
 using Community.VisualStudio.Toolkit;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.PatternMatching;
 using Microsoft.VisualStudio.Threading;
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
-using System.Linq;
-using System.Threading.Tasks;
 using System.Windows;
 
 namespace GitWebLinks;
@@ -28,16 +22,7 @@ public class SelectTargetDialogViewModel : ObservableObject {
     private bool? _dialogResult;
 
 
-    public static async Task<SelectTargetDialogViewModel> CreateAsync(
-        ILinkTargetLoader loader,
-        IPatternMatcherFactory patternMatcherFactory,
-        JoinableTaskFactory joinableTaskFactory
-    ) {
-        return new SelectTargetDialogViewModel(loader, patternMatcherFactory, joinableTaskFactory);
-    }
-
-
-    private SelectTargetDialogViewModel(
+    public SelectTargetDialogViewModel(
         ILinkTargetLoader loader,
         IPatternMatcherFactory patternMatcherFactory,
         JoinableTaskFactory joinableTaskFactory
@@ -47,7 +32,7 @@ public class SelectTargetDialogViewModel : ObservableObject {
         _isLoading = true;
         _filterText = "";
 
-        _allTargets = new List<LinkTargetListItem>();
+        _allTargets = [];
         _filteredTargets = _allTargets.ToList();
         _selectedTarget = _filteredTargets.FirstOrDefault();
 

--- a/visual-studio/source/GitWebLinks/UI/Windows/SelectTargetDialog/SelectTargetDialogViewModel.cs
+++ b/visual-studio/source/GitWebLinks/UI/Windows/SelectTargetDialog/SelectTargetDialogViewModel.cs
@@ -20,8 +20,7 @@ public class SelectTargetDialogViewModel : ObservableObject {
 
     private readonly ILinkTargetLoader _loader;
     private readonly IPatternMatcherFactory _patternMatcherFactory;
-    private readonly IEnumerable<LinkTargetListItem> _presets;
-    private List<LinkTargetListItem> _allTargets;
+    private readonly List<LinkTargetListItem> _allTargets;
     private List<LinkTargetListItem> _filteredTargets;
     private LinkTargetListItem? _selectedTarget;
     private bool _isLoading;
@@ -34,23 +33,21 @@ public class SelectTargetDialogViewModel : ObservableObject {
         IPatternMatcherFactory patternMatcherFactory,
         JoinableTaskFactory joinableTaskFactory
     ) {
-        return new SelectTargetDialogViewModel(await loader.LoadPresetsAsync(), loader, patternMatcherFactory, joinableTaskFactory);
+        return new SelectTargetDialogViewModel(loader, patternMatcherFactory, joinableTaskFactory);
     }
 
 
     private SelectTargetDialogViewModel(
-        IEnumerable<LinkTargetListItem> presets,
         ILinkTargetLoader loader,
         IPatternMatcherFactory patternMatcherFactory,
         JoinableTaskFactory joinableTaskFactory
     ) {
-        _presets = presets;
         _loader = loader;
         _patternMatcherFactory = patternMatcherFactory;
         _isLoading = true;
         _filterText = "";
 
-        _allTargets = _presets.ToList();
+        _allTargets = new List<LinkTargetListItem>();
         _filteredTargets = _allTargets.ToList();
         _selectedTarget = _filteredTargets.FirstOrDefault();
 
@@ -60,11 +57,7 @@ public class SelectTargetDialogViewModel : ObservableObject {
 
     public async Task OnLoadedAsync() {
         try {
-            await Task.WhenAll(
-                PopulatePresetDescriptionsAsync(),
-                LoadRefsAsync()
-            );
-
+            _allTargets.AddRange(await _loader.LoadAsync());
             ApplyFilter();
 
         } catch (Exception ex) when (!ErrorHandler.IsCriticalException(ex)) {
@@ -74,18 +67,6 @@ public class SelectTargetDialogViewModel : ObservableObject {
         }
 
         IsLoading = false;
-    }
-
-
-    private async Task PopulatePresetDescriptionsAsync() {
-        await _loader.PopulatePresetDescriptionsAsync(_presets);
-        ApplyFilter();
-    }
-
-
-    private async Task LoadRefsAsync() {
-        _allTargets = _presets.Concat(await _loader.LoadRefsAsync()).ToList();
-        ApplyFilter();
     }
 
 
@@ -115,7 +96,9 @@ public class SelectTargetDialogViewModel : ObservableObject {
     }
 
 
-    public Visibility NoTargetsVisibility => Targets.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+    public Visibility NoTargetsVisibility => IsLoading ?
+        Visibility.Collapsed :
+        Targets.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
 
 
     public LinkTargetListItem? SelectedTarget {

--- a/visual-studio/source/GitWebLinks/UI/Windows/SelectTargetDialog/SelectTargetDialogViewModel.cs
+++ b/visual-studio/source/GitWebLinks/UI/Windows/SelectTargetDialog/SelectTargetDialogViewModel.cs
@@ -62,7 +62,7 @@ public class SelectTargetDialogViewModel : ObservableObject {
         try {
             await Task.WhenAll(
                 PopulatePresetDescriptionsAsync(),
-                LoadBranchesAndCommitsAsync()
+                LoadRefsAsync()
             );
 
             ApplyFilter();
@@ -83,8 +83,8 @@ public class SelectTargetDialogViewModel : ObservableObject {
     }
 
 
-    private async Task LoadBranchesAndCommitsAsync() {
-        _allTargets = _presets.Concat(await _loader.LoadBranchesAndCommitsAsync()).ToList();
+    private async Task LoadRefsAsync() {
+        _allTargets = _presets.Concat(await _loader.LoadRefsAsync()).ToList();
         ApplyFilter();
     }
 

--- a/visual-studio/source/GitWebLinks/UI/Windows/Toast/Toast.xaml.cs
+++ b/visual-studio/source/GitWebLinks/UI/Windows/Toast/Toast.xaml.cs
@@ -1,6 +1,3 @@
-#nullable enable
-
-using System;
 using System.Drawing;
 using System.Windows;
 using System.Windows.Interop;
@@ -13,7 +10,6 @@ public partial class Toast : Window {
     private static Toast? _current;
     private readonly DispatcherTimer _timer;
     private readonly Window _mainWindow;
-
 
 
     public Toast() {

--- a/visual-studio/source/GitWebLinks/UI/Windows/Toast/ToastViewModel.cs
+++ b/visual-studio/source/GitWebLinks/UI/Windows/Toast/ToastViewModel.cs
@@ -1,9 +1,5 @@
-#nullable enable
-
 using Microsoft.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Threading;
-using System;
-using System.Collections.Generic;
 using System.Windows;
 
 namespace GitWebLinks;

--- a/visual-studio/source/GitWebLinks/Utilities/AsyncPackageExtensions.cs
+++ b/visual-studio/source/GitWebLinks/Utilities/AsyncPackageExtensions.cs
@@ -1,8 +1,4 @@
-#nullable enable
-
 using Microsoft.VisualStudio.Shell;
-using System;
-using System.Threading.Tasks;
 
 namespace GitWebLinks;
 

--- a/visual-studio/source/GitWebLinks/Utilities/NativeMethods.cs
+++ b/visual-studio/source/GitWebLinks/Utilities/NativeMethods.cs
@@ -1,6 +1,3 @@
-#nullable enable
-
-using System;
 using System.IO;
 using System.Runtime.InteropServices;
 

--- a/visual-studio/source/GitWebLinks/Utilities/ResourceHelpers.cs
+++ b/visual-studio/source/GitWebLinks/Utilities/ResourceHelpers.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Globalization;
 
 namespace GitWebLinks;

--- a/visual-studio/source/GitWebLinks/Utilities/StringArrayJsonConverter.cs
+++ b/visual-studio/source/GitWebLinks/Utilities/StringArrayJsonConverter.cs
@@ -1,7 +1,4 @@
-#nullable enable
-
 using Newtonsoft.Json;
-using System;
 
 namespace GitWebLinks;
 
@@ -17,7 +14,7 @@ public class StringArrayJsonConverter : JsonConverter<string> {
             string[] values;
 
 
-            values = serializer.Deserialize<string[]>(reader) ?? Array.Empty<string>();
+            values = serializer.Deserialize<string[]>(reader) ?? [];
 
             return string.Concat(values);
         }

--- a/visual-studio/source/GitWebLinks/Utilities/UrlHelpers.cs
+++ b/visual-studio/source/GitWebLinks/Utilities/UrlHelpers.cs
@@ -1,6 +1,3 @@
-#nullable enable
-
-using System;
 using System.Text.RegularExpressions;
 
 namespace GitWebLinks;

--- a/visual-studio/source/GitWebLinks/source.extension.cs
+++ b/visual-studio/source/GitWebLinks/source.extension.cs
@@ -11,7 +11,7 @@ namespace GitWebLinks
         public const string Name = "Git Web Links";
         public const string Description = @"Copy links to files in their online Git repositories.";
         public const string Language = "en-US";
-        public const string Version = "2.14.1";
+        public const string Version = "2.15.0";
         public const string Author = "reduckted";
         public const string Tags = "";
     }

--- a/visual-studio/source/GitWebLinks/source.extension.vsixmanifest
+++ b/visual-studio/source/GitWebLinks/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="GitWebLinks.c090a256-229d-440e-8f5d-34306611b61b" Version="2.14.1" Language="en-US" Publisher="reduckted" />
+        <Identity Id="GitWebLinks.c090a256-229d-440e-8f5d-34306611b61b" Version="2.15.0" Language="en-US" Publisher="reduckted" />
         <DisplayName>Git Web Links</DisplayName>
         <Description xml:space="preserve">Copy links to files in their online Git repositories.</Description>
         <MoreInfo>https://github.com/reduckted/GitWebLinks</MoreInfo>

--- a/visual-studio/tests/GitWebLinks.UnitTests/Handlers/Definition/ISelectionTest.cs
+++ b/visual-studio/tests/GitWebLinks.UnitTests/Handlers/Definition/ISelectionTest.cs
@@ -2,6 +2,6 @@ namespace GitWebLinks;
 
 public interface ISelectionTest {
 
-    public string Result { get; }
+    string Result { get; }
 
 }

--- a/visual-studio/tests/GitWebLinks.UnitTests/Handlers/Definition/UrlTests.cs
+++ b/visual-studio/tests/GitWebLinks.UnitTests/Handlers/Definition/UrlTests.cs
@@ -17,6 +17,9 @@ public class UrlTests {
     public UrlTest Commit { get; } = new();
 
 
+    public UrlTest? Tag { get; set; }
+
+
     public SelectionTests Selection { get; } = new();
 
 }

--- a/visual-studio/tests/GitWebLinks.UnitTests/Handlers/HandlerTests.cs
+++ b/visual-studio/tests/GitWebLinks.UnitTests/Handlers/HandlerTests.cs
@@ -45,7 +45,10 @@ public static class HandlerTests {
         public async Task Branch() {
             await RunUrlTestAsync(
                 Definition.Tests.CreateUrl.Branch,
-                new TestOptions { Type = LinkType.CurrentBranch, Branch = TestBranchName }
+                new TestOptions {
+                    Target = new LinkTargetPreset(LinkType.CurrentBranch),
+                    Branch = TestBranchName
+                }
             );
         }
 
@@ -54,7 +57,22 @@ public static class HandlerTests {
         public async Task Commit() {
             await RunUrlTestAsync(
                 Definition.Tests.CreateUrl.Commit,
-                new TestOptions { Type = LinkType.Commit }
+                new TestOptions {
+                    Target = new LinkTargetPreset(LinkType.Commit)
+                }
+            );
+        }
+
+
+        [HandlerFact(WhenExists = nameof(UrlTests.Tag))]
+        public async Task Tag() {
+            Assert.NotNull(Definition.Tests.CreateUrl.Tag);
+
+            await RunUrlTestAsync(
+                Definition.Tests.CreateUrl.Tag,
+                new TestOptions {
+                    Target = new LinkTargetRef(new RefInfo(TestTagName, TestTagName), RefType.Tag)
+                }
             );
         }
 
@@ -66,7 +84,7 @@ public static class HandlerTests {
                 Definition.Tests.CreateUrl.Remotes.Settings,
                 Definition.Tests.CreateUrl.Remotes.Result,
                 new TestOptions {
-                    Type = LinkType.DefaultBranch,
+                    Target = new LinkTargetPreset(LinkType.DefaultBranch),
                     RemoteName = "origin",
                     // Run with a different branch to confirm that the remote's default branch is used.
                     Branch = TestBranchName
@@ -100,7 +118,7 @@ public static class HandlerTests {
                     Branch = test.Branch,
                     FileName = test.FileName,
                     Selection = selection,
-                    Type = test.LinkType
+                    Target = new LinkTargetPreset(test.LinkType ?? LinkType.CurrentBranch)
                 }
             );
         }
@@ -137,8 +155,7 @@ public static class HandlerTests {
             await RunTestAsync(
                 remote,
                 Definition.Tests.CreateUrl.Remotes.Settings,
-                Definition.Tests.CreateUrl.Remotes.Result,
-                new TestOptions()
+                Definition.Tests.CreateUrl.Remotes.Result
             );
         }
 
@@ -184,7 +201,7 @@ public static class HandlerTests {
                     repository,
                     match.RemoteUrl,
                     new FileInfo(Path.Combine(RepositoryRoot, options.FileName ?? TestFileName), options.Selection),
-                    new LinkOptions(new LinkTargetPreset(options.Type ?? LinkType.CurrentBranch))
+                    new LinkOptions(options.Target ?? new LinkTargetPreset(LinkType.CurrentBranch))
                 )
             ).Url;
 
@@ -200,7 +217,7 @@ public static class HandlerTests {
             public SelectedRange? Selection { get; set; }
 
 
-            public LinkType? Type { get; set; }
+            public ILinkTarget? Target { get; set; }
 
         }
 
@@ -251,7 +268,6 @@ public static class HandlerTests {
             await RunUrlTestAsync(
                 Definition.Tests.CreateUrl.Branch,
                 new ReverseTestOptions {
-                    Type = LinkType.CurrentBranch,
                     Branch = TestBranchName,
                     FileMayStartWithBranch = Definition.Reverse.FileMayStartWithBranch
                 }
@@ -262,10 +278,17 @@ public static class HandlerTests {
         [HandlerFact]
         public async Task Commit() {
             await RunUrlTestAsync(
-                Definition.Tests.CreateUrl.Commit,
-                new ReverseTestOptions {
-                    Type = LinkType.Commit
-                }
+                Definition.Tests.CreateUrl.Commit
+            );
+        }
+
+
+        [HandlerFact(WhenExists = nameof(UrlTests.Tag))]
+        public async Task Tag() {
+            Assert.NotNull(Definition.Tests.CreateUrl.Tag);
+
+            await RunUrlTestAsync(
+                Definition.Tests.CreateUrl.Tag
             );
         }
 
@@ -295,8 +318,7 @@ public static class HandlerTests {
                     Branch = test.Branch,
                     FileMayStartWithBranch = Definition.Reverse.FileMayStartWithBranch,
                     FileName = test.FileName,
-                    Selection = selection,
-                    Type = test.LinkType
+                    Selection = selection
                 }
             );
         }
@@ -392,9 +414,6 @@ public static class HandlerTests {
             public PartialSelectedRange? Selection { get; set; }
 
 
-            public LinkType? Type { get; set; }
-
-
             public bool FileMayStartWithBranch { get; set; }
 
         }
@@ -427,6 +446,7 @@ public static class HandlerTests {
         protected const string TestFileName = "src/file.txt";
         protected const string TestFileNameWithSpaces = "src/path spaces/file spaces.txt";
         protected const string TestBranchName = "feature/test";
+        protected const string TestTagName = "v1.2.3";
 
 
         private readonly ISettings _settings;

--- a/visual-studio/tests/GitWebLinks.UnitTests/Handlers/xUnit/HandlerFactAttribute.cs
+++ b/visual-studio/tests/GitWebLinks.UnitTests/Handlers/xUnit/HandlerFactAttribute.cs
@@ -3,4 +3,8 @@ using Xunit.v3;
 namespace GitWebLinks;
 
 [XunitTestCaseDiscoverer(typeof(HandlerTestCaseDiscoverer))]
-public sealed class HandlerFactAttribute : FactAttribute { }
+public sealed class HandlerFactAttribute : FactAttribute {
+
+    public string? WhenExists { get; set; }
+
+}

--- a/visual-studio/tests/GitWebLinks.UnitTests/Handlers/xUnit/HandlerTestCaseDiscoverer.cs
+++ b/visual-studio/tests/GitWebLinks.UnitTests/Handlers/xUnit/HandlerTestCaseDiscoverer.cs
@@ -1,3 +1,4 @@
+using System.Linq.Expressions;
 using System.Text.RegularExpressions;
 using Xunit.Internal;
 using Xunit.Sdk;
@@ -12,6 +13,9 @@ public class HandlerTestCaseDiscoverer : IXunitTestCaseDiscoverer {
         IXunitTestMethod testMethod,
         IFactAttribute factAttribute
     ) {
+        IEnumerable<HandlerTestDefinition> definitions;
+        HandlerFactAttribute handlerFactAttribute;
+
 #pragma warning disable IDE0008 // Use explicit type
         var details = TestIntrospectionHelper.GetTestCaseDetails(
             discoveryOptions,
@@ -20,24 +24,47 @@ public class HandlerTestCaseDiscoverer : IXunitTestCaseDiscoverer {
         );
 #pragma warning restore IDE0008 // Use explicit type
 
+        definitions = TestDefinitionProvider.GetDefinitions();
+        handlerFactAttribute = (HandlerFactAttribute)factAttribute;
+
+        if (handlerFactAttribute.WhenExists is not null) {
+            definitions = definitions.Where(CreateDefinitionPredicate(handlerFactAttribute.WhenExists));
+        }
+
         return new ValueTask<IReadOnlyCollection<IXunitTestCase>>(
-            (
-                from definition in TestDefinitionProvider.GetDefinitions()
-                select new HandlerTestCase(
-                    definition.Name,
-                    details.ResolvedTestMethod,
-                    definition.Name,
-                    $"{details.UniqueID}+{Regex.Replace(definition.Name, "\\s\\.", "_")}",
-                    details.Explicit,
-                    details.SkipReason,
-                    details.SkipType,
-                    details.SkipUnless,
-                    details.SkipWhen,
-                    testMethod.Traits.ToReadWrite(StringComparer.OrdinalIgnoreCase),
-                    timeout: details.Timeout
-                )
-            ).ToList()
+            definitions.Select((definition) => new HandlerTestCase(
+                definition.Name,
+                details.ResolvedTestMethod,
+                definition.Name,
+                $"{details.UniqueID}+{Regex.Replace(definition.Name, "\\s\\.", "_")}",
+                details.Explicit,
+                details.SkipReason,
+                details.SkipType,
+                details.SkipUnless,
+                details.SkipWhen,
+                testMethod.Traits.ToReadWrite(StringComparer.OrdinalIgnoreCase),
+                timeout: details.Timeout
+            )).ToList()
         );
+    }
+
+
+    private Func<HandlerTestDefinition, bool> CreateDefinitionPredicate(string requiredPropertyName) {
+        Func<UrlTests, object> accessor;
+        ParameterExpression definition;
+
+
+        definition = Expression.Parameter(typeof(UrlTests));
+
+        accessor = Expression.Lambda<Func<UrlTests, object>>(
+            Expression.Convert(
+                Expression.Property(definition, requiredPropertyName),
+                typeof(object)
+            ),
+            definition
+        ).Compile();
+
+        return (definition) => accessor(definition.Tests.CreateUrl) is not null;
     }
 
 }

--- a/visual-studio/tests/GitWebLinks.UnitTests/Services/LinkHandlerTests.cs
+++ b/visual-studio/tests/GitWebLinks.UnitTests/Services/LinkHandlerTests.cs
@@ -201,6 +201,25 @@ public static class LinkHandlerTests {
 
 
         [Fact]
+        public async Task ShouldUseTheGivenTag() {
+            await SetupRepositoryAsync(RootDirectory);
+
+            Assert.Equal(
+                "short.tag",
+                await CreateUrlAsync(
+                    new PartialHandlerDefinition {
+                        Url = "{{ ref }}.{{ type }}"
+                    },
+                     // For tags, we expect the abbreviated and symbolic values
+                     // to have the same value, but we always use the abbreviated
+                     // value. To verify this, we'll use different values.
+                     new LinkTargetRef(new RefInfo("short", "long"), RefType.Tag)
+                )
+            );
+        }
+
+
+        [Fact]
         public async Task ShouldUseTheGivenShortBranchNameWhenAbbreviatedBranchRefsShouldBeUsed() {
             await SetupRepositoryAsync(RootDirectory);
 
@@ -650,6 +669,7 @@ public static class LinkHandlerTests {
                 new PublicHandlerDefinition(
                     "Test",
                     definition.BranchRef ?? BranchRefType.Abbreviated,
+                    true,
                     [],
                     Parser.Parse(definition.Url ?? ""),
                     definition.Query ?? [],
@@ -862,6 +882,7 @@ public static class LinkHandlerTests {
                 new PublicHandlerDefinition(
                     "Test",
                     BranchRefType.Abbreviated,
+                    true,
                     [],
                     EmptyTemplate,
                     [],

--- a/visual-studio/tests/GitWebLinks.UnitTests/Services/LinkTargetLoaderTests.cs
+++ b/visual-studio/tests/GitWebLinks.UnitTests/Services/LinkTargetLoaderTests.cs
@@ -1,250 +1,31 @@
+using Fluid;
 using NSubstitute;
+using System.Text.RegularExpressions;
 
 namespace GitWebLinks;
 
 public static class LinkTargetLoaderTests {
 
-    public class LoadPresetsAsyncMethod : TestBase {
+    public class LoadAsyncMethod : RepositoryTestBase, IAsyncLifetime {
 
-        [Fact]
-        public async Task ShouldShowCurrentCommitFirstWhenItIsTheDefault() {
-            LinkTargetLoader loader;
-            IReadOnlyList<LinkTargetListItem> presets;
-
-
-            Settings.GetDefaultLinkTypeAsync().Returns(LinkType.Commit);
-
-            loader = CreateLoader(Substitute.For<ILinkHandler>());
-
-            presets = await loader.LoadPresetsAsync();
-
-            Assert.Equal(
-                new[] {
-                    ("Current commit", new LinkType?(LinkType.Commit)),
-                    ("Current branch", new LinkType?(LinkType.CurrentBranch)),
-                    ("Default branch", new LinkType?(LinkType.DefaultBranch))
-                },
-                presets.Select((x) => (x.Name, ((LinkTargetPreset)x.Target).Type)).ToArray()
-            );
-        }
-
-
-        [Fact]
-        public async Task ShouldShowCurrentBranchFirstWhenItIsTheDefault() {
-            LinkTargetLoader loader;
-            IReadOnlyList<LinkTargetListItem> presets;
-
-
-            Settings.GetDefaultLinkTypeAsync().Returns(LinkType.CurrentBranch);
-
-            loader = CreateLoader(Substitute.For<ILinkHandler>());
-
-            presets = await loader.LoadPresetsAsync();
-
-            Assert.Equal(
-                new[] {
-                    ("Current branch", new LinkType?(LinkType.CurrentBranch)),
-                    ("Current commit", new LinkType?(LinkType.Commit)),
-                    ("Default branch", new LinkType?(LinkType.DefaultBranch))
-                },
-                presets.Select((x) => (x.Name, ((LinkTargetPreset)x.Target).Type)).ToArray()
-            );
-        }
-
-
-        [Fact]
-        public async Task ShouldShowDefaultBranchFirstWhenItIsTheDefault() {
-            LinkTargetLoader loader;
-            IReadOnlyList<LinkTargetListItem> presets;
-
-
-            Settings.GetDefaultLinkTypeAsync().Returns(LinkType.DefaultBranch);
-
-            loader = CreateLoader(Substitute.For<ILinkHandler>());
-
-            presets = await loader.LoadPresetsAsync();
-
-            Assert.Equal(
-                new[] {
-                    ("Default branch", new LinkType?(LinkType.DefaultBranch)),
-                    ("Current branch", new LinkType?(LinkType.CurrentBranch)),
-                    ("Current commit", new LinkType?(LinkType.Commit))
-                },
-                presets.Select((x) => (x.Name, ((LinkTargetPreset)x.Target).Type)).ToArray()
-            );
-        }
-
-    }
-
-
-    public class PopulatePresetDescriptionsAsyncMethod : TestBase {
-
-        [Fact]
-        public async Task UsesTheHandlerToGetTheRefNames() {
-            LinkTargetLoader loader;
-            IReadOnlyList<LinkTargetListItem> presets;
-            ILinkHandler handler;
-
-
-            handler = Substitute.For<ILinkHandler>();
-
-            handler.GetRefAsync(LinkType.Commit, Arg.Any<string>(), Arg.Any<Remote>()).Returns("the commit");
-            handler.GetRefAsync(LinkType.CurrentBranch, Arg.Any<string>(), Arg.Any<Remote>()).Returns("the branch");
-            handler.GetRefAsync(LinkType.DefaultBranch, Arg.Any<string>(), Arg.Any<Remote>()).Returns("the default");
-
-            loader = CreateLoader(handler);
-
-            presets = [
-                new LinkTargetListItem(LinkTargetListItemKind.Preset, "Commit", new LinkTargetPreset(LinkType.Commit)),
-                new LinkTargetListItem(LinkTargetListItemKind.Preset, "DefaultBranch", new LinkTargetPreset(LinkType.DefaultBranch)),
-                new LinkTargetListItem(LinkTargetListItemKind.Preset, "CurrentBranch", new LinkTargetPreset(LinkType.CurrentBranch))
-            ];
-
-            await loader.PopulatePresetDescriptionsAsync(presets);
-
-            Assert.Equal(
-                [
-                    "the commit",
-                    "the default",
-                    "the branch"
-                ],
-                presets.Select((x) => x.Description).ToArray()
-            );
-        }
-
-
-        [Fact]
-        public async Task CatchesNoRemoteHeadException() {
-            LinkTargetLoader loader;
-            IReadOnlyList<LinkTargetListItem> presets;
-            ILinkHandler handler;
-
-
-            handler = Substitute.For<ILinkHandler>();
-
-            handler.GetRefAsync(LinkType.Commit, Arg.Any<string>(), Arg.Any<Remote>()).Returns("the commit");
-            handler.GetRefAsync(LinkType.CurrentBranch, Arg.Any<string>(), Arg.Any<Remote>()).Returns("the branch");
-            handler
-                .GetRefAsync(LinkType.DefaultBranch, Arg.Any<string>(), Arg.Any<Remote>())
-                .Returns(Task.FromException<string>(new NoRemoteHeadException("")));
-
-            loader = CreateLoader(handler);
-
-            presets = [
-                new LinkTargetListItem(LinkTargetListItemKind.Preset, "CurrentBranch", new LinkTargetPreset(LinkType.CurrentBranch)),
-                new LinkTargetListItem(LinkTargetListItemKind.Preset, "DefaultBranch", new LinkTargetPreset(LinkType.DefaultBranch)),
-                new LinkTargetListItem(LinkTargetListItemKind.Preset, "Commit", new LinkTargetPreset(LinkType.Commit))
-            ];
-
-            await loader.PopulatePresetDescriptionsAsync(presets);
-
-            Assert.Equal(
-                [
-                    "the branch",
-                    "",
-                    "the commit"
-                ],
-                presets.Select((x) => x.Description).ToArray()
-            );
-        }
-
-    }
-
-
-    public class LoadRefsAsyncMethod : TestBase {
-
+        private readonly Repository _repository;
+        private readonly ISettings _settings;
         private readonly List<Ref> _commitsInBranchOrder = [];
         private readonly List<Ref> _commitsInHashOrder = [];
+        private Ref? _detachedHeadHash;
 
 
-        [Fact]
-        public async Task UsesShortHashesWhenSettingsUseShortHashes() {
-            LinkTargetLoader loader;
-            IReadOnlyList<LinkTargetListItem> items;
+        public LoadAsyncMethod() {
+            _repository = new Repository(RootDirectory, new Remote("origin", ["http://example.com"]));
 
-
-            Settings.GetUseShortHashesAsync().Returns(true);
-            await SetupRepositoryAsync();
-
-            loader = CreateLoader(Substitute.For<ILinkHandler>());
-
-            items = await loader.LoadRefsAsync();
-
-            Assert.Equal(
-                new[] {
-                    ("first", _commitsInBranchOrder[1].Abbreviated, LinkTargetListItemKind.Branch),
-                    ("master", _commitsInBranchOrder[0].Abbreviated, LinkTargetListItemKind.Branch),
-                    ("second", _commitsInBranchOrder[2].Abbreviated, LinkTargetListItemKind.Branch),
-                    (_commitsInHashOrder[0].Abbreviated, _commitsInHashOrder[0].BranchName, LinkTargetListItemKind.Commit),
-                    (_commitsInHashOrder[1].Abbreviated, _commitsInHashOrder[1].BranchName, LinkTargetListItemKind.Commit),
-                    (_commitsInHashOrder[2].Abbreviated, _commitsInHashOrder[2].BranchName, LinkTargetListItemKind.Commit)
-                },
-                items.Select((x) => (x.Name, x.Description, x.Kind)).ToArray()
-            );
+            _settings = Substitute.For<ISettings>();
+            _settings.GetDefaultLinkTypeAsync().Returns(LinkType.DefaultBranch);
+            _settings.GetDefaultBranchAsync().Returns("master");
+            _settings.GetUseShortHashesAsync().Returns(true);
         }
 
 
-        [Fact]
-        public async Task UsesLongHashesWhenSettingsUseLongHashes() {
-            LinkTargetLoader loader;
-            IReadOnlyList<LinkTargetListItem> items;
-
-
-            Settings.GetUseShortHashesAsync().Returns(false);
-            await SetupRepositoryAsync();
-
-            loader = CreateLoader(Substitute.For<ILinkHandler>());
-
-            items = await loader.LoadRefsAsync();
-
-            Assert.Equal(
-                new[] {
-                    ("first", _commitsInBranchOrder[1].Symbolic, LinkTargetListItemKind.Branch),
-                    ("master", _commitsInBranchOrder[0].Symbolic, LinkTargetListItemKind.Branch),
-                    ("second", _commitsInBranchOrder[2].Symbolic, LinkTargetListItemKind.Branch),
-                    (_commitsInHashOrder[0].Symbolic, _commitsInHashOrder[0].BranchName, LinkTargetListItemKind.Commit),
-                    (_commitsInHashOrder[1].Symbolic, _commitsInHashOrder[1].BranchName, LinkTargetListItemKind.Commit),
-                    (_commitsInHashOrder[2].Symbolic, _commitsInHashOrder[2].BranchName, LinkTargetListItemKind.Commit)
-                },
-                items.Select((x) => (x.Name, x.Description, x.Kind)).ToArray()
-            );
-        }
-
-
-        [Fact]
-        public async Task IncludesTagsWhenHandlerSupportsTags() {
-            LinkTargetLoader loader;
-            IReadOnlyList<LinkTargetListItem> items;
-            ILinkHandler handler;
-
-
-            Settings.GetUseShortHashesAsync().Returns(false);
-            await SetupRepositoryAsync();
-
-            handler = Substitute.For<ILinkHandler>();
-            handler.SupportsTags.Returns(true);
-
-            loader = CreateLoader(handler);
-
-            items = await loader.LoadRefsAsync();
-
-            Assert.Equal(
-                new[] {
-                    ("first", _commitsInBranchOrder[1].Symbolic, LinkTargetListItemKind.Branch),
-                    ("master", _commitsInBranchOrder[0].Symbolic, LinkTargetListItemKind.Branch),
-                    ("second", _commitsInBranchOrder[2].Symbolic, LinkTargetListItemKind.Branch),
-                    (_commitsInHashOrder[0].Symbolic, _commitsInHashOrder[0].BranchName, LinkTargetListItemKind.Commit),
-                    (_commitsInHashOrder[1].Symbolic, _commitsInHashOrder[1].BranchName, LinkTargetListItemKind.Commit),
-                    (_commitsInHashOrder[2].Symbolic, _commitsInHashOrder[2].BranchName, LinkTargetListItemKind.Commit),
-                    ("v1.0.0", "", LinkTargetListItemKind.Tag),
-                    ("v2.0.0", "", LinkTargetListItemKind.Tag )
-                },
-                items.Select((x) => (x.Name, x.Description, x.Kind)).ToArray()
-            );
-        }
-
-
-        private async Task SetupRepositoryAsync() {
+        public async ValueTask InitializeAsync() {
             _commitsInBranchOrder.Clear();
             _commitsInHashOrder.Clear();
 
@@ -265,21 +46,413 @@ public static class LinkTargetLoaderTests {
             CreateFile("2");
             await Git.ExecuteAsync(RootDirectory, "add", "*");
             await Git.ExecuteAsync(RootDirectory, "commit", "-m", "2");
+
+            // Store this commit as the one we will use for a detached HEAD state.
+            _detachedHeadHash = await GetRefAsync("second");
+
+            CreateFile("3");
+            await Git.ExecuteAsync(RootDirectory, "add", "*");
+            await Git.ExecuteAsync(RootDirectory, "commit", "-m", "3");
             _commitsInBranchOrder.Add(await GetRefAsync("second"));
 
             await Git.ExecuteAsync(RootDirectory, "tag", "v1.0.0");
             await Git.ExecuteAsync(RootDirectory, "tag", "v2.0.0");
 
             _commitsInHashOrder.AddRange(_commitsInBranchOrder.OrderBy((x) => x.Abbreviated));
+
+            async Task<Ref> GetRefAsync(string branchName) {
+                return new Ref {
+                    Abbreviated = (await Git.ExecuteAsync(RootDirectory, "rev-parse", "--short", "HEAD"))[0].Trim(),
+                    Symbolic = (await Git.ExecuteAsync(RootDirectory, "rev-parse", "HEAD"))[0].Trim(),
+                    BranchName = branchName
+                };
+            }
         }
 
 
-        private async Task<Ref> GetRefAsync(string branchName) {
-            return new Ref {
-                Abbreviated = (await Git.ExecuteAsync(RootDirectory, "rev-parse", "--short", "HEAD"))[0].Trim(),
-                Symbolic = (await Git.ExecuteAsync(RootDirectory, "rev-parse", "HEAD"))[0].Trim(),
-                BranchName = branchName
-            };
+        [Fact]
+        public async Task ShouldShowCurrentCommitPresetFirstWhenItIsTheDefault() {
+            LinkTargetLoader loader;
+            IReadOnlyList<LinkTargetListItem> items;
+
+
+            _settings.GetDefaultLinkTypeAsync().Returns(LinkType.Commit);
+
+            loader = CreateLoader(CreateHandler(false));
+
+            items = await loader.LoadAsync();
+
+            Assert.Equal(
+                new[] {
+                    new TargetItem(
+                        "Current commit",
+                        _commitsInBranchOrder[2].Abbreviated,
+                        LinkType.Commit,
+                        LinkTargetListItemKind.Preset
+                    ),
+                    new TargetItem(
+                        "Current branch",
+                        "second",
+                        LinkType.CurrentBranch,
+                        LinkTargetListItemKind.Preset
+                    ),
+                    new TargetItem(
+                        "Default branch",
+                        "master",
+                        LinkType.DefaultBranch,
+                        LinkTargetListItemKind.Preset
+                    )
+                }.Concat(GetExpectedBranchItems()).Concat(GetExpectedCommitItems()),
+                items.Select((x) => new TargetItem(x.Name, x.Description, (x.Target as LinkTargetPreset)?.Type, x.Kind)).ToArray()
+            );
+        }
+
+
+        [Fact]
+        public async Task ShouldShowCurrentBranchFirstWhenItIsTheDefault() {
+            LinkTargetLoader loader;
+            IReadOnlyList<LinkTargetListItem> items;
+
+
+            _settings.GetDefaultLinkTypeAsync().Returns(LinkType.CurrentBranch);
+
+            loader = CreateLoader(CreateHandler(false));
+
+            items = await loader.LoadAsync();
+
+            Assert.Equal(
+                new[] {
+                    new TargetItem(
+                        "Current branch",
+                        "second",
+                        LinkType.CurrentBranch,
+                        LinkTargetListItemKind.Preset
+                    ),
+                    new TargetItem(
+                        "Current commit",
+                        _commitsInBranchOrder[2].Abbreviated,
+                        LinkType.Commit,
+                        LinkTargetListItemKind.Preset
+                    ),
+                    new TargetItem(
+                        "Default branch",
+                        "master",
+                        LinkType.DefaultBranch,
+                        LinkTargetListItemKind.Preset
+                    )
+                }.Concat(GetExpectedBranchItems()).Concat(GetExpectedCommitItems()),
+                items.Select((x) => new TargetItem(x.Name, x.Description, (x.Target as LinkTargetPreset)?.Type, x.Kind)).ToArray()
+            );
+        }
+
+
+        [Fact]
+        public async Task ShouldShowDefaultBranchFirstWhenItIsTheDefault() {
+            LinkTargetLoader loader;
+            IReadOnlyList<LinkTargetListItem> items;
+
+
+            _settings.GetDefaultLinkTypeAsync().Returns(LinkType.DefaultBranch);
+
+            loader = CreateLoader(CreateHandler(false));
+
+            items = await loader.LoadAsync();
+
+            Assert.Equal(
+                new[] {
+                     new TargetItem(
+                        "Default branch",
+                        "master",
+                        LinkType.DefaultBranch,
+                        LinkTargetListItemKind.Preset
+                    ),
+                    new TargetItem(
+                        "Current branch",
+                        "second",
+                        LinkType.CurrentBranch,
+                        LinkTargetListItemKind.Preset
+                    ),
+                    new TargetItem(
+                        "Current commit",
+                        _commitsInBranchOrder[2].Abbreviated,
+                        LinkType.Commit,
+                        LinkTargetListItemKind.Preset
+                    )
+                }.Concat(GetExpectedBranchItems()).Concat(GetExpectedCommitItems()),
+                items.Select((x) => new TargetItem(x.Name, x.Description, (x.Target as LinkTargetPreset)?.Type, x.Kind)).ToArray()
+            );
+        }
+
+
+        [Fact]
+        public async Task CatchesNoRemoteHeadException() {
+            LinkTargetLoader loader;
+            IReadOnlyList<LinkTargetListItem> items;
+            ILinkHandler handler;
+
+
+            handler = Substitute.For<ILinkHandler>();
+
+            handler.SupportsTags.Returns(false);
+            handler.GetRefAsync(LinkType.Commit, Arg.Any<string>(), Arg.Any<Remote>()).Returns("the commit");
+            handler.GetRefAsync(LinkType.CurrentBranch, Arg.Any<string>(), Arg.Any<Remote>()).Returns("the branch");
+            handler
+                .GetRefAsync(LinkType.DefaultBranch, Arg.Any<string>(), Arg.Any<Remote>())
+                .Returns(Task.FromException<string>(new NoRemoteHeadException("")));
+
+            loader = CreateLoader(handler);
+
+            items = await loader.LoadAsync();
+
+            Assert.Equal(
+                new[] {
+                     new TargetItem(
+                        "Default branch",
+                        "",
+                        LinkType.DefaultBranch,
+                        LinkTargetListItemKind.Preset
+                    ),
+                    new TargetItem(
+                        "Current branch",
+                        "the branch",
+                        LinkType.CurrentBranch,
+                        LinkTargetListItemKind.Preset
+                    ),
+                    new TargetItem(
+                        "Current commit",
+                        "the commit",
+                        LinkType.Commit,
+                        LinkTargetListItemKind.Preset
+                    )
+                }.Concat(GetExpectedBranchItems()).Concat(GetExpectedCommitItems()),
+                items.Select((x) => new TargetItem(x.Name, x.Description, (x.Target as LinkTargetPreset)?.Type, x.Kind)).ToArray()
+            );
+        }
+
+
+        [Fact]
+        public async Task ShouldOmitCurrentBranchWhenItIsDetachedHead() {
+            Assert.NotNull(_detachedHeadHash);
+            await Git.ExecuteAsync(RootDirectory, "checkout", _detachedHeadHash.Symbolic);
+
+            try {
+                LinkTargetLoader loader;
+                IReadOnlyList<LinkTargetListItem> items;
+
+
+                loader = CreateLoader(CreateHandler(false));
+
+                items = await loader.LoadAsync();
+
+                Assert.Equal(
+                    new[] {
+                        new TargetItem(
+                            "Default branch",
+                            "master",
+                            LinkType.DefaultBranch,
+                            LinkTargetListItemKind.Preset
+                        ),
+                        new TargetItem(
+                            "Current commit",
+                            _detachedHeadHash.Abbreviated,
+                            LinkType.Commit,
+                            LinkTargetListItemKind.Preset
+                        )
+                    }.Concat(GetExpectedBranchItems()).Concat(
+                        GetExpectedCommitItems().Append(
+                            new TargetItem(
+                                _detachedHeadHash.Abbreviated,
+                                $"(HEAD detached at {_detachedHeadHash.Abbreviated})",
+                                default,
+                                LinkTargetListItemKind.Commit
+                            )
+                        ).OrderBy((x) => x.Name)
+                    ),
+                    items.Select((x) => new TargetItem(x.Name, x.Description, (x.Target as LinkTargetPreset)?.Type, x.Kind)).ToArray()
+                );
+
+            } finally {
+                await Git.ExecuteAsync(RootDirectory, "checkout", "-");
+            }
+        }
+
+
+        [Fact]
+        public async Task UsesLongHashesWhenSettingsUseLongHashes() {
+            LinkTargetLoader loader;
+            IReadOnlyList<LinkTargetListItem> items;
+
+
+            _settings.GetUseShortHashesAsync().Returns(false);
+
+            loader = CreateLoader(CreateHandler(false));
+
+            items = await loader.LoadAsync();
+
+            Assert.Equal(
+                new[] {
+                    ("Default branch", _commitsInBranchOrder[0].BranchName),
+                    ("Current branch", _commitsInBranchOrder[2].BranchName),
+                    ("Current commit", _commitsInBranchOrder[2].Symbolic),
+                    ("first", _commitsInBranchOrder[1].Symbolic),
+                    ("master", _commitsInBranchOrder[0].Symbolic),
+                    ("second", _commitsInBranchOrder[2].Symbolic),
+                    (_commitsInHashOrder[0].Symbolic, _commitsInHashOrder[0].BranchName),
+                    (_commitsInHashOrder[1].Symbolic, _commitsInHashOrder[1].BranchName),
+                    (_commitsInHashOrder[2].Symbolic, _commitsInHashOrder[2].BranchName)
+                },
+                items.Select((x) => (x.Name, x.Description)).ToArray()
+            );
+        }
+
+
+        [Fact]
+        public async Task IncludesTagsWhenHandlerSupportsTags() {
+            LinkTargetLoader loader;
+            IReadOnlyList<LinkTargetListItem> items;
+
+
+            loader = CreateLoader(CreateHandler(true));
+
+            items = await loader.LoadAsync();
+
+            Assert.Equal(
+                new[] {
+                     new TargetItem(
+                        "Default branch",
+                        "master",
+                        LinkType.DefaultBranch,
+                        LinkTargetListItemKind.Preset
+                    ),
+                    new TargetItem(
+                        "Current branch",
+                        "second",
+                        LinkType.CurrentBranch,
+                        LinkTargetListItemKind.Preset
+                    ),
+                    new TargetItem(
+                        "Current commit",
+                        _commitsInBranchOrder[2].Abbreviated,
+                        LinkType.Commit,
+                        LinkTargetListItemKind.Preset
+                    )
+                }.Concat(GetExpectedBranchItems()).Concat(GetExpectedCommitItems()).Concat(
+                    new[] {
+                        new TargetItem(
+                            "v1.0.0",
+                            "",
+                            null,
+                            LinkTargetListItemKind.Tag
+                        ),
+                        new TargetItem(
+                            "v2.0.0",
+                            "",
+                            null,
+                            LinkTargetListItemKind.Tag
+                        )
+                    }
+                ),
+                items.Select((x) => new TargetItem(x.Name, x.Description, (x.Target as LinkTargetPreset)?.Type, x.Kind)).ToArray()
+            );
+        }
+
+
+        private IEnumerable<TargetItem> GetExpectedBranchItems() {
+            yield return new TargetItem(
+                "first",
+                _commitsInBranchOrder[1].Abbreviated,
+                null,
+                LinkTargetListItemKind.Branch
+            );
+
+            yield return new TargetItem(
+                "master",
+                _commitsInBranchOrder[0].Abbreviated,
+                null,
+                LinkTargetListItemKind.Branch
+            );
+
+            yield return new TargetItem(
+                "second",
+                _commitsInBranchOrder[2].Abbreviated,
+                null,
+                LinkTargetListItemKind.Branch
+            );
+        }
+
+
+        private IEnumerable<TargetItem> GetExpectedCommitItems() {
+            yield return new TargetItem(
+                _commitsInHashOrder[0].Abbreviated,
+                _commitsInHashOrder[0].BranchName,
+                null,
+                LinkTargetListItemKind.Commit
+            );
+
+            yield return new TargetItem(
+                _commitsInHashOrder[1].Abbreviated,
+                _commitsInHashOrder[1].BranchName,
+                null,
+                LinkTargetListItemKind.Commit
+            );
+
+            yield return new TargetItem(
+                _commitsInHashOrder[2].Abbreviated,
+                _commitsInHashOrder[2].BranchName,
+                null,
+                LinkTargetListItemKind.Commit
+            );
+        }
+
+
+        private ILinkHandler CreateHandler(bool supportsTags) {
+            FluidParser parser;
+            IFluidTemplate emptyTemplate;
+
+
+            parser = new FluidParser();
+            emptyTemplate = parser.Parse("");
+
+            return new LinkHandler(
+                new PublicHandlerDefinition(
+                    "test",
+                    BranchRefType.Abbreviated,
+                    supportsTags,
+                    Array.Empty<string>(),
+                    emptyTemplate,
+                    Array.Empty<QueryModification>(),
+                    emptyTemplate,
+                    new ReverseSettings(
+                        new Regex(""),
+                        new FluidParser().Parse(""),
+                        false,
+                        new ReverseServerSettings(
+                            emptyTemplate,
+                            emptyTemplate,
+                            emptyTemplate
+                        ),
+                        new ReverseSelectionSettings(
+                            emptyTemplate,
+                            null,
+                            null,
+                            null
+                        )
+                    ),
+                    Array.Empty<IServer>()
+                ),
+                _settings,
+                Git
+            );
+        }
+
+
+        private LinkTargetLoader CreateLoader(ILinkHandler handler) {
+            return new LinkTargetLoader(_settings, Git, handler, _repository, NullLogger.Instance);
+        }
+
+
+        public ValueTask DisposeAsync() {
+            return default;
         }
 
 
@@ -295,25 +468,20 @@ public static class LinkTargetLoaderTests {
 
         }
 
-    }
+
+        private struct TargetItem(string name, string description, LinkType? presetType, LinkTargetListItemKind kind) {
+
+            public readonly string Name => name;
 
 
-    public abstract class TestBase : RepositoryTestBase {
-
-        public TestBase() {
-            Repository = new Repository(RootDirectory, new Remote("origin", ["http://example.com"]));
-            Settings = Substitute.For<ISettings>();
-        }
+            public readonly string Description => description;
 
 
-        protected Repository Repository { get; }
+            public readonly LinkType? PresetType => presetType;
 
 
-        protected ISettings Settings { get; }
+            public readonly LinkTargetListItemKind Kind => kind;
 
-
-        protected LinkTargetLoader CreateLoader(ILinkHandler handler) {
-            return new LinkTargetLoader(Settings, Git, handler, Repository, NullLogger.Instance);
         }
 
     }

--- a/visual-studio/tests/GitWebLinks.UnitTests/Services/LinkTargetLoaderTests.cs
+++ b/visual-studio/tests/GitWebLinks.UnitTests/Services/LinkTargetLoaderTests.cs
@@ -337,7 +337,7 @@ public static class LinkTargetLoaderTests {
                         LinkTargetListItemKind.Preset
                     )
                 }.Concat(GetExpectedBranchItems()).Concat(GetExpectedCommitItems()).Concat(
-                    new[] {
+                    [
                         new TargetItem(
                             "v1.0.0",
                             "",
@@ -350,7 +350,7 @@ public static class LinkTargetLoaderTests {
                             null,
                             LinkTargetListItemKind.Tag
                         )
-                    }
+                    ]
                 ),
                 items.Select((x) => new TargetItem(x.Name, x.Description, (x.Target as LinkTargetPreset)?.Type, x.Kind)).ToArray()
             );
@@ -418,9 +418,9 @@ public static class LinkTargetLoaderTests {
                     "test",
                     BranchRefType.Abbreviated,
                     supportsTags,
-                    Array.Empty<string>(),
+                    [],
                     emptyTemplate,
-                    Array.Empty<QueryModification>(),
+                    [],
                     emptyTemplate,
                     new ReverseSettings(
                         new Regex(""),
@@ -438,7 +438,7 @@ public static class LinkTargetLoaderTests {
                             null
                         )
                     ),
-                    Array.Empty<IServer>()
+                    []
                 ),
                 _settings,
                 Git

--- a/visual-studio/tests/GitWebLinks.UnitTests/Services/LinkTargetLoaderTests.cs
+++ b/visual-studio/tests/GitWebLinks.UnitTests/Services/LinkTargetLoaderTests.cs
@@ -151,7 +151,7 @@ public static class LinkTargetLoaderTests {
     }
 
 
-    public class LoadBranchesAndCommitsAsyncMethod : TestBase {
+    public class LoadRefsAsyncMethod : TestBase {
 
         private readonly List<Ref> _commitsInBranchOrder = [];
         private readonly List<Ref> _commitsInHashOrder = [];
@@ -168,7 +168,7 @@ public static class LinkTargetLoaderTests {
 
             loader = CreateLoader(Substitute.For<ILinkHandler>());
 
-            items = await loader.LoadBranchesAndCommitsAsync();
+            items = await loader.LoadRefsAsync();
 
             Assert.Equal(
                 new[] {
@@ -195,7 +195,7 @@ public static class LinkTargetLoaderTests {
 
             loader = CreateLoader(Substitute.For<ILinkHandler>());
 
-            items = await loader.LoadBranchesAndCommitsAsync();
+            items = await loader.LoadRefsAsync();
 
             Assert.Equal(
                 new[] {
@@ -205,6 +205,39 @@ public static class LinkTargetLoaderTests {
                     (_commitsInHashOrder[0].Symbolic, _commitsInHashOrder[0].BranchName, LinkTargetListItemKind.Commit),
                     (_commitsInHashOrder[1].Symbolic, _commitsInHashOrder[1].BranchName, LinkTargetListItemKind.Commit),
                     (_commitsInHashOrder[2].Symbolic, _commitsInHashOrder[2].BranchName, LinkTargetListItemKind.Commit)
+                },
+                items.Select((x) => (x.Name, x.Description, x.Kind)).ToArray()
+            );
+        }
+
+
+        [Fact]
+        public async Task IncludesTagsWhenHandlerSupportsTags() {
+            LinkTargetLoader loader;
+            IReadOnlyList<LinkTargetListItem> items;
+            ILinkHandler handler;
+
+
+            Settings.GetUseShortHashesAsync().Returns(false);
+            await SetupRepositoryAsync();
+
+            handler = Substitute.For<ILinkHandler>();
+            handler.SupportsTags.Returns(true);
+
+            loader = CreateLoader(handler);
+
+            items = await loader.LoadRefsAsync();
+
+            Assert.Equal(
+                new[] {
+                    ("first", _commitsInBranchOrder[1].Symbolic, LinkTargetListItemKind.Branch),
+                    ("master", _commitsInBranchOrder[0].Symbolic, LinkTargetListItemKind.Branch),
+                    ("second", _commitsInBranchOrder[2].Symbolic, LinkTargetListItemKind.Branch),
+                    (_commitsInHashOrder[0].Symbolic, _commitsInHashOrder[0].BranchName, LinkTargetListItemKind.Commit),
+                    (_commitsInHashOrder[1].Symbolic, _commitsInHashOrder[1].BranchName, LinkTargetListItemKind.Commit),
+                    (_commitsInHashOrder[2].Symbolic, _commitsInHashOrder[2].BranchName, LinkTargetListItemKind.Commit),
+                    ("v1.0.0", "", LinkTargetListItemKind.Tag),
+                    ("v2.0.0", "", LinkTargetListItemKind.Tag )
                 },
                 items.Select((x) => (x.Name, x.Description, x.Kind)).ToArray()
             );
@@ -233,6 +266,9 @@ public static class LinkTargetLoaderTests {
             await Git.ExecuteAsync(RootDirectory, "add", "*");
             await Git.ExecuteAsync(RootDirectory, "commit", "-m", "2");
             _commitsInBranchOrder.Add(await GetRefAsync("second"));
+
+            await Git.ExecuteAsync(RootDirectory, "tag", "v1.0.0");
+            await Git.ExecuteAsync(RootDirectory, "tag", "v2.0.0");
 
             _commitsInHashOrder.AddRange(_commitsInBranchOrder.OrderBy((x) => x.Abbreviated));
         }

--- a/visual-studio/tests/GitWebLinks.UnitTests/UI/Windows/SelectTargetDialog/SelectTargetDialogViewModelTests.cs
+++ b/visual-studio/tests/GitWebLinks.UnitTests/UI/Windows/SelectTargetDialog/SelectTargetDialogViewModelTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.PatternMatching;
 using Microsoft.VisualStudio.Threading;
@@ -9,58 +10,56 @@ namespace GitWebLinks;
 
 public sealed class SelectTargetDialogViewModelTests : IDisposable {
 
-    private readonly JoinableTaskContext _joinableTaskContext = new();
+    private readonly JoinableTaskContext _joinableTaskContext;
+    private readonly ILinkTargetLoader _loader;
 
 
-    [Fact]
-    public async Task IsInitializedWithPresets() {
-        SelectTargetDialogViewModel viewModel;
-        ILinkTargetLoader loader;
+    public SelectTargetDialogViewModelTests() {
+        _joinableTaskContext = new JoinableTaskContext();
 
-
-        loader = CreateLoader(
+        _loader = CreateLoader(
             [
-                new LinkTargetListItem(LinkTargetListItemKind.Preset, "one", Substitute.For<ILinkTarget>()),
-                new LinkTargetListItem(LinkTargetListItemKind.Preset, "two", Substitute.For<ILinkTarget>()),
-                new LinkTargetListItem(LinkTargetListItemKind.Preset, "three", Substitute.For<ILinkTarget>())
-            ],
-            [],
-            []
+                new LinkTargetListItem(
+                LinkTargetListItemKind.Preset,
+                "one",
+                "alpha",
+                KnownMonikers.Abbreviation,
+                Substitute.For<ILinkTarget>()
+            ),
+            new LinkTargetListItem(
+                LinkTargetListItemKind.Preset,
+                "two",
+                "beta",
+                KnownMonikers.Abbreviation,
+                Substitute.For<ILinkTarget>()
+            ),
+            new LinkTargetListItem(
+                LinkTargetListItemKind.Preset,
+                "three",
+                "gamma",
+                KnownMonikers.Abbreviation,
+                Substitute.For<ILinkTarget>()
+            ),
+            new LinkTargetListItem(
+                LinkTargetListItemKind.Preset,
+                "four",
+                "delta",
+                KnownMonikers.Abbreviation,
+                Substitute.For <ILinkTarget>()
+            )
+            ]
         );
 
-        viewModel = await SelectTargetDialogViewModel.CreateAsync(
-            loader,
-            Substitute.For<IPatternMatcherFactory>(),
-            new JoinableTaskFactory(_joinableTaskContext)
-        );
-
-        Assert.Equal(["one", "two", "three"], viewModel.Targets.Select((x) => x.Name));
-
-        await loader.Received(1).LoadPresetsAsync();
-        Assert.Single(loader.ReceivedCalls());
     }
 
 
     [Fact]
-    public async Task LoadsPresetDescriptionsAndBranchesAndCommitsOnLoad() {
+    public async Task LoadsItemsOnLoad() {
         SelectTargetDialogViewModel viewModel;
-        ILinkTargetLoader loader;
 
-
-        loader = CreateLoader(
-            [
-                new LinkTargetListItem(LinkTargetListItemKind.Preset, "one", Substitute.For<ILinkTarget>()),
-                new LinkTargetListItem(LinkTargetListItemKind.Preset, "two", Substitute.For<ILinkTarget>())
-            ],
-            ["1", "2"],
-            [
-                new LinkTargetListItem(LinkTargetListItemKind.Preset, "three", Substitute.For<ILinkTarget>()) { Description = "3" },
-                new LinkTargetListItem(LinkTargetListItemKind.Preset, "four", Substitute.For <ILinkTarget>()) { Description = "4" }
-            ]
-        );
 
         viewModel = await SelectTargetDialogViewModel.CreateAsync(
-            loader,
+            _loader,
             Substitute.For<IPatternMatcherFactory>(),
             new JoinableTaskFactory(_joinableTaskContext)
         );
@@ -75,41 +74,25 @@ public sealed class SelectTargetDialogViewModelTests : IDisposable {
 
         Assert.Equal(
             [
-                ("one", "1"),
-                ("two", "2"),
-                ("three", "3"),
-                ("four", "4")
+                ("one", "alpha"),
+                ("two", "beta"),
+                ("three", "gamma"),
+                ("four", "delta")
             ],
             viewModel.Targets.Select((x) => (x.Name, x.Description))
         );
 
-        await loader.Received(1).LoadPresetsAsync();
-        await loader.Received(1).PopulatePresetDescriptionsAsync(Arg.Any<IEnumerable<LinkTargetListItem>>());
-        await loader.Received(1).LoadRefsAsync();
-        Assert.Equal(3, loader.ReceivedCalls().Count());
+        await _loader.Received(1).LoadAsync();
     }
 
 
     [Fact]
     public async Task CanFilterTargetsByName() {
         SelectTargetDialogViewModel viewModel;
-        ILinkTargetLoader loader;
 
-
-        loader = CreateLoader(
-        [
-                new LinkTargetListItem(LinkTargetListItemKind.Preset, "one", Substitute.For<ILinkTarget>()),
-                new LinkTargetListItem(LinkTargetListItemKind.Preset, "two", Substitute.For<ILinkTarget>())
-            ],
-            ["1", "2"],
-            [
-                new LinkTargetListItem(LinkTargetListItemKind.Preset, "three", Substitute.For<ILinkTarget>()) { Description = "3" },
-                new LinkTargetListItem(LinkTargetListItemKind.Preset, "four", Substitute.For<ILinkTarget>()) { Description = "4" }
-            ]
-        );
 
         viewModel = await SelectTargetDialogViewModel.CreateAsync(
-            loader,
+            _loader,
             CreateMatcherFactory(),
             new JoinableTaskFactory(_joinableTaskContext)
         );
@@ -119,10 +102,10 @@ public sealed class SelectTargetDialogViewModelTests : IDisposable {
         Assert.Equal(Visibility.Collapsed, viewModel.NoTargetsVisibility);
         Assert.Equal(["one", "two", "three", "four"], viewModel.Targets.Select((x) => x.Name));
 
-        viewModel.FilterText = "t";
+        viewModel.FilterText = "o";
 
         Assert.Equal(Visibility.Collapsed, viewModel.NoTargetsVisibility);
-        Assert.Equal(["two", "three"], viewModel.Targets.Select((x) => x.Name));
+        Assert.Equal(["one", "two", "four"], viewModel.Targets.Select((x) => x.Name));
 
         viewModel.FilterText = "x";
 
@@ -139,23 +122,10 @@ public sealed class SelectTargetDialogViewModelTests : IDisposable {
     [Fact]
     public async Task CanFilterTargetsByDescription() {
         SelectTargetDialogViewModel viewModel;
-        ILinkTargetLoader loader;
 
-
-        loader = CreateLoader(
-            [
-                new LinkTargetListItem(LinkTargetListItemKind.Preset, "1", Substitute.For<ILinkTarget>()),
-                new LinkTargetListItem(LinkTargetListItemKind.Preset, "2", Substitute.For<ILinkTarget>())
-            ],
-            ["first", "second"],
-            [
-                new LinkTargetListItem(LinkTargetListItemKind.Preset, "3", Substitute.For<ILinkTarget>()) { Description = "third" },
-                new LinkTargetListItem(LinkTargetListItemKind.Preset, "4", Substitute.For<ILinkTarget>()) { Description = "fourth" }
-            ]
-        );
 
         viewModel = await SelectTargetDialogViewModel.CreateAsync(
-            loader,
+            _loader,
             CreateMatcherFactory(),
             new JoinableTaskFactory(_joinableTaskContext)
         );
@@ -163,12 +133,12 @@ public sealed class SelectTargetDialogViewModelTests : IDisposable {
         await viewModel.OnLoadedAsync();
 
         Assert.Equal(Visibility.Collapsed, viewModel.NoTargetsVisibility);
-        Assert.Equal(["first", "second", "third", "fourth"], viewModel.Targets.Select((x) => x.Description));
+        Assert.Equal(["alpha", "beta", "gamma", "delta"], viewModel.Targets.Select((x) => x.Description));
 
-        viewModel.FilterText = "t";
+        viewModel.FilterText = "l";
 
         Assert.Equal(Visibility.Collapsed, viewModel.NoTargetsVisibility);
-        Assert.Equal(["first", "third", "fourth"], viewModel.Targets.Select((x) => x.Description));
+        Assert.Equal(["alpha", "delta"], viewModel.Targets.Select((x) => x.Description));
 
         viewModel.FilterText = "x";
 
@@ -178,72 +148,38 @@ public sealed class SelectTargetDialogViewModelTests : IDisposable {
         viewModel.FilterText = "";
 
         Assert.Equal(Visibility.Collapsed, viewModel.NoTargetsVisibility);
-        Assert.Equal(["first", "second", "third", "fourth"], viewModel.Targets.Select((x) => x.Description));
+        Assert.Equal(["alpha", "beta", "gamma", "delta"], viewModel.Targets.Select((x) => x.Description));
     }
 
 
     [Fact]
     public async Task AppliesFilterAfterLoading() {
         SelectTargetDialogViewModel viewModel;
-        ILinkTargetLoader loader;
 
-
-        loader = CreateLoader(
-            [
-                new LinkTargetListItem(LinkTargetListItemKind.Preset, "one", Substitute.For<ILinkTarget>()),
-                new LinkTargetListItem(LinkTargetListItemKind.Preset, "two", Substitute.For<ILinkTarget>())
-            ],
-            ["1", "2"],
-            [
-                new LinkTargetListItem(LinkTargetListItemKind.Preset, "three", Substitute.For<ILinkTarget>()) { Description = "3" },
-                new LinkTargetListItem(LinkTargetListItemKind.Preset, "four", Substitute.For<ILinkTarget>()) { Description = "4" }
-            ]
-        );
 
         viewModel = await SelectTargetDialogViewModel.CreateAsync(
-            loader,
+            _loader,
             CreateMatcherFactory(),
             new JoinableTaskFactory(_joinableTaskContext)
         );
 
-        viewModel.FilterText = "t";
-        Assert.Equal(["two"], viewModel.Targets.Select((x) => x.Name));
+        viewModel.FilterText = "o";
+        Assert.Empty(viewModel.Targets);
 
         await viewModel.OnLoadedAsync();
-        Assert.Equal(["two", "three"], viewModel.Targets.Select((x) => x.Name));
+        Assert.Equal(["one", "two", "four"], viewModel.Targets.Select((x) => x.Name));
 
         viewModel.FilterText = "";
         Assert.Equal(["one", "two", "three", "four"], viewModel.Targets.Select((x) => x.Name));
     }
 
 
-    private ILinkTargetLoader CreateLoader(
-        IReadOnlyList<LinkTargetListItem> presets,
-        IReadOnlyList<string> presetDescriptions,
-        IReadOnlyList<LinkTargetListItem> branchesAndCommits
-    ) {
+    private ILinkTargetLoader CreateLoader(IReadOnlyList<LinkTargetListItem> items) {
         ILinkTargetLoader loader;
 
 
         loader = Substitute.For<ILinkTargetLoader>();
-
-        loader.LoadPresetsAsync().Returns(presets);
-
-        loader.PopulatePresetDescriptionsAsync(Arg.Any<IEnumerable<LinkTargetListItem>>()).Returns(
-            (args) => {
-                IEnumerable<LinkTargetListItem> collection;
-
-                collection = args.ArgAt<IEnumerable<LinkTargetListItem>>(0);
-
-                foreach ((LinkTargetListItem preset, string description) in collection.Zip(presetDescriptions, (preset, description) => (preset, description))) {
-                    preset.Description = description;
-                }
-
-                return Task.CompletedTask;
-            }
-        );
-
-        loader.LoadRefsAsync().Returns(branchesAndCommits);
+        loader.LoadAsync().Returns(items);
 
         return loader;
     }

--- a/visual-studio/tests/GitWebLinks.UnitTests/UI/Windows/SelectTargetDialog/SelectTargetDialogViewModelTests.cs
+++ b/visual-studio/tests/GitWebLinks.UnitTests/UI/Windows/SelectTargetDialog/SelectTargetDialogViewModelTests.cs
@@ -58,7 +58,7 @@ public sealed class SelectTargetDialogViewModelTests : IDisposable {
         SelectTargetDialogViewModel viewModel;
 
 
-        viewModel = await SelectTargetDialogViewModel.CreateAsync(
+        viewModel = new SelectTargetDialogViewModel(
             _loader,
             Substitute.For<IPatternMatcherFactory>(),
             new JoinableTaskFactory(_joinableTaskContext)
@@ -91,7 +91,7 @@ public sealed class SelectTargetDialogViewModelTests : IDisposable {
         SelectTargetDialogViewModel viewModel;
 
 
-        viewModel = await SelectTargetDialogViewModel.CreateAsync(
+        viewModel = new SelectTargetDialogViewModel(
             _loader,
             CreateMatcherFactory(),
             new JoinableTaskFactory(_joinableTaskContext)
@@ -124,7 +124,7 @@ public sealed class SelectTargetDialogViewModelTests : IDisposable {
         SelectTargetDialogViewModel viewModel;
 
 
-        viewModel = await SelectTargetDialogViewModel.CreateAsync(
+        viewModel = new SelectTargetDialogViewModel(
             _loader,
             CreateMatcherFactory(),
             new JoinableTaskFactory(_joinableTaskContext)
@@ -157,13 +157,12 @@ public sealed class SelectTargetDialogViewModelTests : IDisposable {
         SelectTargetDialogViewModel viewModel;
 
 
-        viewModel = await SelectTargetDialogViewModel.CreateAsync(
+        viewModel = new SelectTargetDialogViewModel(
             _loader,
             CreateMatcherFactory(),
             new JoinableTaskFactory(_joinableTaskContext)
-        );
+        ) { FilterText = "o" };
 
-        viewModel.FilterText = "o";
         Assert.Empty(viewModel.Targets);
 
         await viewModel.OnLoadedAsync();

--- a/visual-studio/tests/GitWebLinks.UnitTests/UI/Windows/SelectTargetDialog/SelectTargetDialogViewModelTests.cs
+++ b/visual-studio/tests/GitWebLinks.UnitTests/UI/Windows/SelectTargetDialog/SelectTargetDialogViewModelTests.cs
@@ -85,7 +85,7 @@ public sealed class SelectTargetDialogViewModelTests : IDisposable {
 
         await loader.Received(1).LoadPresetsAsync();
         await loader.Received(1).PopulatePresetDescriptionsAsync(Arg.Any<IEnumerable<LinkTargetListItem>>());
-        await loader.Received(1).LoadBranchesAndCommitsAsync();
+        await loader.Received(1).LoadRefsAsync();
         Assert.Equal(3, loader.ReceivedCalls().Count());
     }
 
@@ -243,7 +243,7 @@ public sealed class SelectTargetDialogViewModelTests : IDisposable {
             }
         );
 
-        loader.LoadBranchesAndCommitsAsync().Returns(branchesAndCommits);
+        loader.LoadRefsAsync().Returns(branchesAndCommits);
 
         return loader;
     }

--- a/vscode/.vscode/settings.json
+++ b/vscode/.vscode/settings.json
@@ -7,7 +7,9 @@
     },
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-        "source.fixAll": "explicit"
+        "source.fixAll.eslint": "explicit",
+        "source.fixAll.prettier": "never",
+        "source.fixAll.ts": "never"
     },
     "search.exclude": {
         "dist": true,

--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-gitweblinks",
-    "version": "2.14.1",
+    "version": "2.15.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-gitweblinks",
-            "version": "2.14.1",
+            "version": "2.15.0",
             "license": "MIT",
             "dependencies": {
                 "liquidjs": "10.26.0"

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-gitweblinks",
     "displayName": "Git Web Links for VS Code",
     "description": "Copy links to files in their online Git repositories",
-    "version": "2.14.1",
+    "version": "2.15.0",
     "publisher": "reduckted",
     "homepage": "https://github.com/reduckted/GitWebLinks",
     "repository": {

--- a/vscode/src/commands/get-link-command.ts
+++ b/vscode/src/commands/get-link-command.ts
@@ -309,7 +309,7 @@ export class GetLinkCommand {
         items = [
             {
                 item: {
-                    label: 'Current branch',
+                    label: '$(git-branch) Current branch',
                     description: targets[0],
                     target: { preset: 'branch' }
                 },
@@ -317,7 +317,7 @@ export class GetLinkCommand {
             },
             {
                 item: {
-                    label: 'Current commit',
+                    label: '$(git-commit) Current commit',
                     description: targets[1],
                     target: { preset: 'commit' }
                 },
@@ -325,7 +325,7 @@ export class GetLinkCommand {
             },
             {
                 item: {
-                    label: 'Default branch',
+                    label: '$(git-branch) Default branch',
                     description: targets[2],
                     target: { preset: 'defaultBranch' }
                 },
@@ -397,13 +397,13 @@ export class GetLinkCommand {
             let [branchName, branchRef, shortHash, fullHash] = line.split(' ');
 
             branches.push({
-                label: branchName,
+                label: `$(git-branch) ${branchName}`,
                 description: useShortHashes ? shortHash : fullHash,
                 target: { ref: { abbreviated: branchName, symbolic: branchRef }, type: 'branch' }
             });
 
             commits.push({
-                label: useShortHashes ? shortHash : fullHash,
+                label: `$(git-commit) ${useShortHashes ? shortHash : fullHash}`,
                 description: branchName,
                 target: { ref: { abbreviated: shortHash, symbolic: fullHash }, type: 'commit' }
             });
@@ -414,7 +414,7 @@ export class GetLinkCommand {
 
         for (let line of tagOutput.split(/\r?\n/).filter((x) => x.length > 0)) {
             tags.push({
-                label: `${line}`,
+                label: `$(tag) ${line}`,
                 target: {
                     ref: { abbreviated: line, symbolic: line },
                     type: 'tag'

--- a/vscode/src/commands/get-link-command.ts
+++ b/vscode/src/commands/get-link-command.ts
@@ -258,15 +258,9 @@ export class GetLinkCommand {
      * @returns The target, or undefined to cancel the operation.
      */
     private async promptForLinkTarget(info: ResourceInfo): Promise<LinkTarget | undefined> {
-        let items: (QuickPickItem | QuickPickLinkTargetItem)[];
         let selection: QuickPickItem | QuickPickLinkTargetItem | undefined;
 
-        items = [
-            ...(await this.getPresetTargetItems(info)),
-            ...(await this.getRefTargetItems(info))
-        ];
-
-        selection = await window.showQuickPick(items, {
+        selection = await window.showQuickPick(this.getQuickPickItems(info), {
             placeHolder: 'What would you like to create the link to?',
             matchOnDescription: true
         });
@@ -276,6 +270,20 @@ export class GetLinkCommand {
         }
 
         return undefined;
+    }
+
+    /**
+     * Gets the quick pick items for the link target selection.
+     *
+     * @param info The info for the resource that the link will be created for.
+     * @returns The quick pick items.
+     */
+    private async getQuickPickItems(
+        info: ResourceInfo
+    ): Promise<(QuickPickItem | QuickPickLinkTargetItem)[]> {
+        return (
+            await Promise.all([this.getPresetTargetItems(info), this.getRefTargetItems(info)])
+        ).flat();
     }
 
     /**
@@ -361,27 +369,31 @@ export class GetLinkCommand {
     ): Promise<(QuickPickItem | QuickPickLinkTargetItem)[]> {
         let branches: (QuickPickItem | QuickPickLinkTargetItem)[];
         let commits: (QuickPickItem | QuickPickLinkTargetItem)[];
-        let lines: string[];
+        let tags: (QuickPickItem | QuickPickLinkTargetItem)[];
+        let branchOutput: string;
+        let tagOutput: string;
         let useShortHashes: boolean;
 
-        lines = (
-            await this.git.exec(
+        [branchOutput, tagOutput] = await Promise.all([
+            this.git.exec(
                 info.repository.root,
                 'branch',
                 '--list',
                 '--no-color',
                 '--format',
                 '%(refname:short) %(refname) %(objectname:short) %(objectname)'
-            )
-        )
-            .split(/\r?\n/)
-            .filter((x) => x.length > 0);
+            ),
+            info.handler.supportsTags
+                ? this.git.exec(info.repository.root, 'tag', '--points-at', 'HEAD')
+                : Promise.resolve('')
+        ]);
 
         branches = [];
         commits = [];
+        tags = [];
         useShortHashes = this.settings.getUseShortHash();
 
-        for (let line of lines) {
+        for (let line of branchOutput.split(/\r?\n/).filter((x) => x.length > 0)) {
             let [branchName, branchRef, shortHash, fullHash] = line.split(' ');
 
             branches.push({
@@ -400,11 +412,24 @@ export class GetLinkCommand {
         branches.sort((x, y) => x.label.localeCompare(y.label));
         commits.sort((x, y) => x.label.localeCompare(y.label));
 
+        for (let line of tagOutput.split(/\r?\n/).filter((x) => x.length > 0)) {
+            tags.push({
+                label: `${line}`,
+                target: {
+                    ref: { abbreviated: line, symbolic: line },
+                    type: 'tag'
+                }
+            });
+        }
+
         return [
             { label: 'Branches', kind: QuickPickItemKind.Separator },
             ...branches,
             { label: 'Commits', kind: QuickPickItemKind.Separator },
-            ...commits
+            ...commits,
+            ...(tags.length > 0
+                ? [{ label: 'Tags', kind: QuickPickItemKind.Separator }, ...tags]
+                : [])
         ];
     }
 
@@ -549,7 +574,7 @@ interface ResourceInfo {
 /**
  * An quick pick item for selecting a link target.
  */
-interface QuickPickLinkTargetItem extends QuickPickItem {
+export interface QuickPickLinkTargetItem extends QuickPickItem {
     /**
      * The target that the item represents.
      */

--- a/vscode/src/commands/get-link-command.ts
+++ b/vscode/src/commands/get-link-command.ts
@@ -305,16 +305,22 @@ export class GetLinkCommand {
         ]);
 
         defaultType = this.settings.getDefaultLinkType();
+        items = [];
 
-        items = [
-            {
+        // Omit the current branch as a preset target
+        // if the current commit is a detached HEAD.
+        if (targets[0] !== 'HEAD') {
+            items.push({
                 item: {
                     label: '$(git-branch) Current branch',
                     description: targets[0],
                     target: { preset: 'branch' }
                 },
                 default: defaultType === 'branch'
-            },
+            });
+        }
+
+        items.push(
             {
                 item: {
                     label: '$(git-commit) Current commit',
@@ -331,7 +337,7 @@ export class GetLinkCommand {
                 },
                 default: defaultType === 'defaultBranch'
             }
-        ];
+        );
 
         // Sort the presets so that the default link type is at
         // the top. This will cause it to be the initial selection.
@@ -381,7 +387,7 @@ export class GetLinkCommand {
                 '--list',
                 '--no-color',
                 '--format',
-                '%(refname:short) %(refname) %(objectname:short) %(objectname)'
+                '%(refname:short)~%(refname)~%(objectname:short)~%(objectname)'
             ),
             info.handler.supportsTags
                 ? this.git.exec(info.repository.root, 'tag', '--points-at', 'HEAD')
@@ -394,13 +400,19 @@ export class GetLinkCommand {
         useShortHashes = this.settings.getUseShortHash();
 
         for (let line of branchOutput.split(/\r?\n/).filter((x) => x.length > 0)) {
-            let [branchName, branchRef, shortHash, fullHash] = line.split(' ');
+            let [branchName, branchRef, shortHash, fullHash] = line.split('~');
 
-            branches.push({
-                label: `$(git-branch) ${branchName}`,
-                description: useShortHashes ? shortHash : fullHash,
-                target: { ref: { abbreviated: branchName, symbolic: branchRef }, type: 'branch' }
-            });
+            // Omit the branch item for a detached HEAD, but include the commit.
+            if (!branchName.startsWith('(HEAD detached')) {
+                branches.push({
+                    label: `$(git-branch) ${branchName}`,
+                    description: useShortHashes ? shortHash : fullHash,
+                    target: {
+                        ref: { abbreviated: branchName, symbolic: branchRef },
+                        type: 'branch'
+                    }
+                });
+            }
 
             commits.push({
                 label: `$(git-commit) ${useShortHashes ? shortHash : fullHash}`,

--- a/vscode/src/git.ts
+++ b/vscode/src/git.ts
@@ -78,7 +78,12 @@ export class Git extends Disposable {
         log('Executing git %s', args.join(' '));
 
         child = spawn(this.api.git.path, args, {
-            cwd: typeof root === 'string' ? root : root.fsPath
+            cwd: typeof root === 'string' ? root : root.fsPath,
+            env: {
+                ...process.env,
+                LANG: 'C.UTF-8',
+                LC_ALL: 'C.UTF-8'
+            }
         });
 
         let [code, stdout, stderr] = await Promise.all([

--- a/vscode/src/link-handler.ts
+++ b/vscode/src/link-handler.ts
@@ -103,6 +103,13 @@ export class LinkHandler {
     }
 
     /**
+     * Indicates whether the handler supports creating links for tags.
+     */
+    public get supportsTags(): boolean {
+        return !!this.definition.supportsTags;
+    }
+
+    /**
      * Determines whether this handler can generate links for the given remote URL.
      *
      * @param remoteUrl The remote URL to check.
@@ -128,7 +135,7 @@ export class LinkHandler {
         options: LinkOptions
     ): Promise<CreateUrlResult> {
         let address: StaticServer;
-        let type: LinkType;
+        let type: UrlData['type'];
         let ref: string;
         let url: string;
         let data: UrlData;
@@ -138,20 +145,37 @@ export class LinkHandler {
         // If a link type wasn't specified, then we'll use
         // the default type that's defined in the settings.
         if ('preset' in options.target) {
-            type = options.target.preset ?? this.settings.getDefaultLinkType();
-            ref = await this.getRef(type, repository);
+            let presetType: LinkType;
+
+            presetType = options.target.preset ?? this.settings.getDefaultLinkType();
+
+            ref = await this.getRef(presetType, repository);
+
+            // Presets are either commits or branches.
+            type = presetType === 'commit' ? 'commit' : 'branch';
         } else {
-            if (options.target.type === 'branch') {
-                type = 'branch';
-                ref =
-                    this.definition.branchRef === 'abbreviated'
+            switch (options.target.type) {
+                case 'branch':
+                    type = 'branch';
+                    ref =
+                        this.definition.branchRef === 'abbreviated'
+                            ? options.target.ref.abbreviated
+                            : options.target.ref.symbolic;
+                    break;
+
+                case 'tag':
+                    type = 'tag';
+                    // We don't differentiate between abbreviated and symbolic
+                    // refs for tags, so just use the abbreviated ref value.
+                    ref = options.target.ref.abbreviated;
+                    break;
+
+                default:
+                    type = 'commit';
+                    ref = this.settings.getUseShortHash()
                         ? options.target.ref.abbreviated
                         : options.target.ref.symbolic;
-            } else {
-                type = 'commit';
-                ref = this.settings.getUseShortHash()
-                    ? options.target.ref.abbreviated
-                    : options.target.ref.symbolic;
+                    break;
             }
         }
 
@@ -164,7 +188,7 @@ export class LinkHandler {
             ref,
             commit: await this.getRef('commit', repository),
             file: relativePath,
-            type: type === 'commit' ? 'commit' : 'branch',
+            type,
             sshUserSpecification: getSshUserSpecification(remoteUrl),
             ...file.selection
         };
@@ -572,7 +596,7 @@ interface UrlData {
     /**
      * The type of link being generated.
      */
-    readonly type: 'branch' | 'commit';
+    readonly type: 'branch' | 'commit' | 'tag';
 
     /**
      * The Git ref to generate the link to. This will be a branch name or commit hash depending on the link type.

--- a/vscode/src/schema.ts
+++ b/vscode/src/schema.ts
@@ -43,6 +43,11 @@ export interface HandlerDefinitionBase {
     readonly branchRef: 'abbreviated' | 'symbolic';
 
     /**
+     * Whether the handler supports creating links to tags.
+     */
+    readonly supportsTags?: boolean;
+
+    /**
      * The keys of settings to make available to this handler when rendering templates.
      */
     readonly settingsKeys?: string[];

--- a/vscode/src/types.ts
+++ b/vscode/src/types.ts
@@ -103,7 +103,7 @@ export interface LinkTargetRef {
     /**
      * What the ref refers to.
      */
-    readonly type: 'branch' | 'commit';
+    readonly type: 'branch' | 'commit' | 'tag';
 }
 
 export interface LinkTargetPreset {

--- a/vscode/test/commands/get-link-command.test.ts
+++ b/vscode/test/commands/get-link-command.test.ts
@@ -618,17 +618,17 @@ describe('GetLinkCommand', () => {
 
             expectedPresets = [
                 {
-                    label: 'Current commit',
+                    label: '$(git-commit) Current commit',
                     description: commits[2].abbreviated,
                     target: { preset: 'commit' }
                 },
                 {
-                    label: 'Current branch',
+                    label: '$(git-branch) Current branch',
                     description: 'second',
                     target: { preset: 'branch' }
                 },
                 {
-                    label: 'Default branch',
+                    label: '$(git-branch) Default branch',
                     description: 'master',
                     target: { preset: 'defaultBranch' }
                 }
@@ -636,7 +636,7 @@ describe('GetLinkCommand', () => {
 
             expectedBranches = [
                 {
-                    label: 'first',
+                    label: '$(git-branch) first',
                     description: commits[1].abbreviated,
                     target: {
                         ref: { abbreviated: 'first', symbolic: 'refs/heads/first' },
@@ -644,7 +644,7 @@ describe('GetLinkCommand', () => {
                     }
                 },
                 {
-                    label: 'master',
+                    label: '$(git-branch) master',
                     description: commits[0].abbreviated,
                     target: {
                         ref: { abbreviated: 'master', symbolic: 'refs/heads/master' },
@@ -652,7 +652,7 @@ describe('GetLinkCommand', () => {
                     }
                 },
                 {
-                    label: 'second',
+                    label: '$(git-branch) second',
                     description: commits[2].abbreviated,
                     target: {
                         ref: { abbreviated: 'second', symbolic: 'refs/heads/second' },
@@ -663,17 +663,17 @@ describe('GetLinkCommand', () => {
 
             expectedCommits = [
                 {
-                    label: commits[0].abbreviated,
+                    label: '$(git-commit) ' + commits[0].abbreviated,
                     description: 'master',
                     target: { ref: commits[0], type: 'commit' as const }
                 },
                 {
-                    label: commits[1].abbreviated,
+                    label: '$(git-commit) ' + commits[1].abbreviated,
                     description: 'first',
                     target: { ref: commits[1], type: 'commit' as const }
                 },
                 {
-                    label: commits[2].abbreviated,
+                    label: '$(git-commit) ' + commits[2].abbreviated,
                     description: 'second',
                     target: { ref: commits[2], type: 'commit' as const }
                 }
@@ -681,14 +681,14 @@ describe('GetLinkCommand', () => {
 
             expectedTags = [
                 {
-                    label: 'v1.0.0',
+                    label: '$(tag) v1.0.0',
                     target: {
                         ref: { abbreviated: 'v1.0.0', symbolic: 'v1.0.0' },
                         type: 'tag'
                     }
                 },
                 {
-                    label: 'v2.0.0',
+                    label: '$(tag) v2.0.0',
                     target: {
                         ref: { abbreviated: 'v2.0.0', symbolic: 'v2.0.0' },
                         type: 'tag'

--- a/vscode/test/commands/get-link-command.test.ts
+++ b/vscode/test/commands/get-link-command.test.ts
@@ -613,13 +613,20 @@ describe('GetLinkCommand', () => {
             await git.exec(root.path, 'commit', '-m', '2');
             commits.push(await getRef());
 
+            // Add another commit so that we can checkout the
+            // previous commit and end up in a detached HEAD state.
+            await fs.writeFile(path.join(root.path, '3'), '');
+            await git.exec(root.path, 'add', '*');
+            await git.exec(root.path, 'commit', '-m', '3');
+            commits.push(await getRef());
+
             await git.exec(root.path, 'tag', 'v1.0.0');
             await git.exec(root.path, 'tag', 'v2.0.0');
 
             expectedPresets = [
                 {
                     label: '$(git-commit) Current commit',
-                    description: commits[2].abbreviated,
+                    description: commits[3].abbreviated,
                     target: { preset: 'commit' }
                 },
                 {
@@ -653,7 +660,7 @@ describe('GetLinkCommand', () => {
                 },
                 {
                     label: '$(git-branch) second',
-                    description: commits[2].abbreviated,
+                    description: commits[3].abbreviated,
                     target: {
                         ref: { abbreviated: 'second', symbolic: 'refs/heads/second' },
                         type: 'branch'
@@ -673,9 +680,9 @@ describe('GetLinkCommand', () => {
                     target: { ref: commits[1], type: 'commit' as const }
                 },
                 {
-                    label: '$(git-commit) ' + commits[2].abbreviated,
+                    label: '$(git-commit) ' + commits[3].abbreviated,
                     description: 'second',
-                    target: { ref: commits[2], type: 'commit' as const }
+                    target: { ref: commits[3], type: 'commit' as const }
                 }
             ].sort((a, b) => a.label.localeCompare(b.label));
 
@@ -695,8 +702,6 @@ describe('GetLinkCommand', () => {
                     }
                 }
             ];
-
-            commits.sort((x, y) => x.abbreviated.localeCompare(y.abbreviated));
         });
 
         beforeEach(() => {
@@ -768,6 +773,51 @@ describe('GetLinkCommand', () => {
             ]);
         });
 
+        it('should omit detached HEAD from list of branches.', async () => {
+            await git.exec(root.path, 'checkout', commits[2].symbolic);
+
+            try {
+                sinon.stub(Settings.prototype, 'getUseShortHash').returns(true);
+                sinon.stub(Settings.prototype, 'getDefaultBranch').returns('master');
+
+                expectToExist(selectedHandler);
+                sinon.stub(selectedHandler.handler, 'supportsTags').get(() => true);
+
+                showQuickPick.resolves(undefined);
+
+                await command.execute(file);
+
+                expect(await showQuickPick.getCall(0).args[0]).to.deep.equal([
+                    {
+                        label: '$(git-commit) Current commit',
+                        description: commits[2].abbreviated,
+                        target: { preset: 'commit' }
+                    },
+                    {
+                        label: '$(git-branch) Default branch',
+                        description: 'master',
+                        target: { preset: 'defaultBranch' }
+                    },
+                    { label: 'Branches', kind: QuickPickItemKind.Separator },
+                    // The expected branches don't change. The detached HEAD would be listed
+                    // by `git branch`, but it should be omitted from the quick pick items.
+                    ...expectedBranches,
+                    { label: 'Commits', kind: QuickPickItemKind.Separator },
+                    // The commit for the detached HEAD should be included.
+                    ...[
+                        ...expectedCommits,
+                        {
+                            label: '$(git-commit) ' + commits[2].abbreviated,
+                            description: '(HEAD detached at ' + commits[2].abbreviated + ')',
+                            target: { ref: commits[2], type: 'commit' as const }
+                        }
+                    ].sort((a, b) => a.label.localeCompare(b.label))
+                ]);
+            } finally {
+                await git.exec(root.path, 'checkout', '-');
+            }
+        });
+
         getLinkTypes()
             .filter((x): x is LinkType => x !== undefined)
             .forEach((type) => {
@@ -795,12 +845,7 @@ describe('GetLinkCommand', () => {
                 repository,
                 selectedHandler?.remoteUrl,
                 { uri: file, selection: undefined },
-                {
-                    target: {
-                        ref: { abbreviated: 'first', symbolic: 'refs/heads/first' },
-                        type: 'branch'
-                    }
-                }
+                { target: expectedBranches[0].target }
             );
 
             showQuickPick.callsFake(async (items) => (await items)[5]);
@@ -810,12 +855,7 @@ describe('GetLinkCommand', () => {
                 repository,
                 selectedHandler?.remoteUrl,
                 { uri: file, selection: undefined },
-                {
-                    target: {
-                        ref: { abbreviated: 'master', symbolic: 'refs/heads/master' },
-                        type: 'branch'
-                    }
-                }
+                { target: expectedBranches[1].target }
             );
 
             showQuickPick.callsFake(async (items) => (await items)[6]);
@@ -825,12 +865,7 @@ describe('GetLinkCommand', () => {
                 repository,
                 selectedHandler?.remoteUrl,
                 { uri: file, selection: undefined },
-                {
-                    target: {
-                        ref: { abbreviated: 'second', symbolic: 'refs/heads/second' },
-                        type: 'branch'
-                    }
-                }
+                { target: expectedBranches[2].target }
             );
         });
 
@@ -842,7 +877,7 @@ describe('GetLinkCommand', () => {
                 repository,
                 selectedHandler?.remoteUrl,
                 { uri: file, selection: undefined },
-                { target: { ref: commits[0], type: 'commit' } }
+                { target: expectedCommits[0].target }
             );
 
             showQuickPick.callsFake(async (items) => (await items)[9]);
@@ -852,7 +887,7 @@ describe('GetLinkCommand', () => {
                 repository,
                 selectedHandler?.remoteUrl,
                 { uri: file, selection: undefined },
-                { target: { ref: commits[1], type: 'commit' } }
+                { target: expectedCommits[1].target }
             );
 
             showQuickPick.callsFake(async (items) => (await items)[10]);
@@ -862,7 +897,7 @@ describe('GetLinkCommand', () => {
                 repository,
                 selectedHandler?.remoteUrl,
                 { uri: file, selection: undefined },
-                { target: { ref: commits[2], type: 'commit' } }
+                { target: expectedCommits[2].target }
             );
         });
 

--- a/vscode/test/commands/get-link-command.test.ts
+++ b/vscode/test/commands/get-link-command.test.ts
@@ -7,7 +7,10 @@ import type {
     TextDocument
 } from 'vscode';
 
-import type { GetLinkCommandOptions } from '../../src/commands/get-link-command';
+import type {
+    GetLinkCommandOptions,
+    QuickPickLinkTargetItem
+} from '../../src/commands/get-link-command';
 import type { Git } from '../../src/git';
 import type { CreateUrlResult } from '../../src/link-handler';
 import type { SelectedLinkHandler } from '../../src/link-handler-provider';
@@ -25,7 +28,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import { env, Position, Uri, window } from 'vscode';
+import { env, Position, QuickPickItemKind, Uri, window } from 'vscode';
 
 import { GetLinkCommand } from '../../src/commands/get-link-command';
 import { LinkHandler } from '../../src/link-handler';
@@ -33,7 +36,7 @@ import { LinkHandlerProvider } from '../../src/link-handler-provider';
 import { RepositoryFinder } from '../../src/repository-finder';
 import { Settings } from '../../src/settings';
 import { STRINGS } from '../../src/strings';
-import { Directory, getGitService, markAsSlow, setupRepository } from '../helpers';
+import { Directory, expectToExist, getGitService, markAsSlow, setupRepository } from '../helpers';
 
 const expect = chai.use(sinonChai).expect;
 
@@ -54,8 +57,11 @@ describe('GetLinkCommand', () => {
     let repository: Repository | undefined;
     let link: string | undefined;
 
-    beforeEach(() => {
+    before(() => {
         git = getGitService();
+    });
+
+    beforeEach(() => {
         finder = new RepositoryFinder(git);
         sinon.stub(finder, 'findRepository').callsFake(() => repository);
 
@@ -575,6 +581,10 @@ describe('GetLinkCommand', () => {
             ],
             Thenable<QuickPickItem | undefined>
         >;
+        let expectedPresets: QuickPickLinkTargetItem[];
+        let expectedBranches: QuickPickLinkTargetItem[];
+        let expectedCommits: QuickPickLinkTargetItem[];
+        let expectedTags: QuickPickLinkTargetItem[];
 
         // We need to create repositories, so mark the
         // tests as being a bit slower than other tests.
@@ -602,6 +612,89 @@ describe('GetLinkCommand', () => {
             await git.exec(root.path, 'add', '*');
             await git.exec(root.path, 'commit', '-m', '2');
             commits.push(await getRef());
+
+            await git.exec(root.path, 'tag', 'v1.0.0');
+            await git.exec(root.path, 'tag', 'v2.0.0');
+
+            expectedPresets = [
+                {
+                    label: 'Current commit',
+                    description: commits[2].abbreviated,
+                    target: { preset: 'commit' }
+                },
+                {
+                    label: 'Current branch',
+                    description: 'second',
+                    target: { preset: 'branch' }
+                },
+                {
+                    label: 'Default branch',
+                    description: 'master',
+                    target: { preset: 'defaultBranch' }
+                }
+            ];
+
+            expectedBranches = [
+                {
+                    label: 'first',
+                    description: commits[1].abbreviated,
+                    target: {
+                        ref: { abbreviated: 'first', symbolic: 'refs/heads/first' },
+                        type: 'branch'
+                    }
+                },
+                {
+                    label: 'master',
+                    description: commits[0].abbreviated,
+                    target: {
+                        ref: { abbreviated: 'master', symbolic: 'refs/heads/master' },
+                        type: 'branch'
+                    }
+                },
+                {
+                    label: 'second',
+                    description: commits[2].abbreviated,
+                    target: {
+                        ref: { abbreviated: 'second', symbolic: 'refs/heads/second' },
+                        type: 'branch'
+                    }
+                }
+            ];
+
+            expectedCommits = [
+                {
+                    label: commits[0].abbreviated,
+                    description: 'master',
+                    target: { ref: commits[0], type: 'commit' as const }
+                },
+                {
+                    label: commits[1].abbreviated,
+                    description: 'first',
+                    target: { ref: commits[1], type: 'commit' as const }
+                },
+                {
+                    label: commits[2].abbreviated,
+                    description: 'second',
+                    target: { ref: commits[2], type: 'commit' as const }
+                }
+            ].sort((a, b) => a.label.localeCompare(b.label));
+
+            expectedTags = [
+                {
+                    label: 'v1.0.0',
+                    target: {
+                        ref: { abbreviated: 'v1.0.0', symbolic: 'v1.0.0' },
+                        type: 'tag'
+                    }
+                },
+                {
+                    label: 'v2.0.0',
+                    target: {
+                        ref: { abbreviated: 'v2.0.0', symbolic: 'v2.0.0' },
+                        type: 'tag'
+                    }
+                }
+            ];
 
             commits.sort((x, y) => x.abbreviated.localeCompare(y.abbreviated));
         });
@@ -631,6 +724,48 @@ describe('GetLinkCommand', () => {
             await command.execute(file);
 
             expect(createUrl).to.have.not.been.called;
+        });
+
+        it('should show branches and commits when the handler does not support tags.', async () => {
+            sinon.stub(Settings.prototype, 'getUseShortHash').returns(true);
+            sinon.stub(Settings.prototype, 'getDefaultBranch').returns('master');
+
+            expectToExist(selectedHandler);
+            sinon.stub(selectedHandler.handler, 'supportsTags').get(() => false);
+
+            showQuickPick.resolves(undefined);
+
+            await command.execute(file);
+
+            expect(await showQuickPick.getCall(0).args[0]).to.deep.equal([
+                ...expectedPresets,
+                { label: 'Branches', kind: QuickPickItemKind.Separator },
+                ...expectedBranches,
+                { label: 'Commits', kind: QuickPickItemKind.Separator },
+                ...expectedCommits
+            ]);
+        });
+
+        it('should show branches, commits and tags when the handler supports tags.', async () => {
+            sinon.stub(Settings.prototype, 'getUseShortHash').returns(true);
+            sinon.stub(Settings.prototype, 'getDefaultBranch').returns('master');
+
+            expectToExist(selectedHandler);
+            sinon.stub(selectedHandler.handler, 'supportsTags').get(() => true);
+
+            showQuickPick.resolves(undefined);
+
+            await command.execute(file);
+
+            expect(await showQuickPick.getCall(0).args[0]).to.deep.equal([
+                ...expectedPresets,
+                { label: 'Branches', kind: QuickPickItemKind.Separator },
+                ...expectedBranches,
+                { label: 'Commits', kind: QuickPickItemKind.Separator },
+                ...expectedCommits,
+                { label: 'Tags', kind: QuickPickItemKind.Separator },
+                ...expectedTags
+            ]);
         });
 
         getLinkTypes()

--- a/vscode/test/handlers.test.ts
+++ b/vscode/test/handlers.test.ts
@@ -32,6 +32,7 @@ import { Directory, getGitService, markAsSlow, setupRemote, setupRepository } fr
 const TEST_FILE_NAME: string = 'src/file.txt';
 const TEST_FILE_NAME_WITH_SPACES: string = 'src/path spaces/file spaces.txt';
 const TEST_BRANCH_NAME: string = 'feature/test';
+const TEST_TAG_NAME: string = 'v1.2.3';
 
 let definitions: HandlerWithTests[];
 
@@ -125,6 +126,17 @@ describe('Link handlers', function () {
                     await runUrlTest('commit', { target: { preset: 'commit' } });
                 });
 
+                if (definition.supportsTags) {
+                    it('tag', async () => {
+                        await runUrlTest('tag', {
+                            target: {
+                                ref: { abbreviated: TEST_TAG_NAME, symbolic: TEST_TAG_NAME },
+                                type: 'tag'
+                            }
+                        });
+                    });
+                }
+
                 it('default branch', async () => {
                     await runTest(
                         {
@@ -193,7 +205,13 @@ describe('Link handlers', function () {
                     name: UrlTestName,
                     options: TestOptions = {}
                 ): Promise<void> {
-                    await runTest(definition.tests.createUrl[name], options);
+                    if (definition.tests.createUrl[name]) {
+                        await runTest(definition.tests.createUrl[name], options);
+                    } else {
+                        throw new Error(
+                            `Test '${name}' is not defined for handler '${definition.name}'.`
+                        );
+                    }
                 }
 
                 async function runSelectionTest<T extends SelectionTestName>(
@@ -295,6 +313,17 @@ describe('Link handlers', function () {
                     await runUrlTest('commit', { target: { preset: 'commit' } });
                 });
 
+                if (definition.supportsTags) {
+                    it('tag', async () => {
+                        await runUrlTest('tag', {
+                            target: {
+                                ref: { abbreviated: TEST_TAG_NAME, symbolic: TEST_TAG_NAME },
+                                type: 'tag'
+                            }
+                        });
+                    });
+                }
+
                 definition.tests.createUrl.misc?.forEach((test) => {
                     it(test.name, async () => {
                         await runTest(
@@ -337,7 +366,13 @@ describe('Link handlers', function () {
                     name: UrlTestName,
                     options: ReverseTestOptions = {}
                 ): Promise<void> {
-                    await runTest(definition.tests.createUrl[name], options);
+                    if (definition.tests.createUrl[name]) {
+                        await runTest(definition.tests.createUrl[name], options);
+                    } else {
+                        throw new Error(
+                            `Test '${name}' is not defined for handler '${definition.name}'.`
+                        );
+                    }
                 }
 
                 async function runSelectionTest<T extends SelectionTestName>(

--- a/vscode/test/helpers/index.ts
+++ b/vscode/test/helpers/index.ts
@@ -2,6 +2,7 @@ import type { Uri } from 'vscode';
 
 import type { Git } from '../../src/git';
 
+import { expect } from 'chai';
 import { promises as fs } from 'fs';
 import * as path from 'path';
 import * as sinon from 'sinon';
@@ -90,4 +91,13 @@ export async function tick(): Promise<void> {
  */
 export function matchUri(expected: Uri): sinon.SinonMatcher {
     return sinon.match((actual: Uri) => expected.toString() === actual.toString());
+}
+
+/**
+ * Asserts that the value is not undefined.
+ *
+ * @param value The value to test.
+ */
+export function expectToExist<T>(value: T | undefined): asserts value is T {
+    expect(value).to.not.be.undefined; // eslint-disable-line @typescript-eslint/no-unused-expressions
 }

--- a/vscode/test/link-handler.test.ts
+++ b/vscode/test/link-handler.test.ts
@@ -174,6 +174,25 @@ describe('LinkHandler', function () {
             ).to.equal('long.commit');
         });
 
+        it('should use the given tag.', async () => {
+            await setupRepository(root.path);
+
+            expect(
+                await createUrl(
+                    { url: '{{ ref }}.{{ type }}' },
+                    {
+                        target: {
+                            // For tags, we expect the abbreviated and symbolic values
+                            // to have the same value, but we always use the abbreviated
+                            // value. To verify this, we'll use different values.
+                            ref: { abbreviated: 'short', symbolic: 'long' },
+                            type: 'tag'
+                        }
+                    }
+                )
+            ).to.equal('short.tag');
+        });
+
         it('should use the given short branch name when abbreviated branch refs should be used.', async () => {
             await setupRepository(root.path);
 

--- a/vscode/test/test-schema.ts
+++ b/vscode/test/test-schema.ts
@@ -61,6 +61,11 @@ export interface UrlTests {
     commit: UrlTest;
 
     /**
+     * A test for creating a link using a tag.
+     */
+    tag?: UrlTest;
+
+    /**
      * Tests for including the selected range in the URL.
      */
     selection: SelectionTests;


### PR DESCRIPTION
For GitHub and GitHub Enterprise, you can now select a tag to create the commit to. 

Only tags on the current commit can be selected. Because not every commit has a tag, this is only available in the command that lets you choose the type.

VS Code: 
_Copy Link to Selection (choose type)_ (command name is `gitweblinks.copySelectionToChoice`)
<img width="621" height="239" alt="image" src="https://github.com/user-attachments/assets/8c33db8e-bd45-4628-8f26-b499ce55462e" />

Visual Studio:
_Copy Link to Target..._ (command name is `GitWebLinks.CopyLinkForTarget`)
<img width="458" height="259" alt="image" src="https://github.com/user-attachments/assets/c1a508fb-824c-468a-a838-252b92646d4c" />



Closes #387 